### PR TITLE
Update receiver_sat_states in place (map!) instead of rebuilding it every frame

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -137,7 +137,19 @@ function bench_process_without_acquisition()
     rs, plan_args = make_receiver_and_plan()
     locked = run_process(rs, plan_args, @view(CHUNKS[1:N_LOCK]), NEVER)
     timed_chunks = CHUNKS[N_LOCK+1:N_LOCK+N_RUN]
-    @benchmarkable run_process($locked, $plan_args, $timed_chunks, NEVER)
+    # `process` mutates the receiver state in place — the in-place `track!`
+    # (c1c8b26) and the in-place `map!` in `update_receiver_sat_states`. If every
+    # BenchmarkTools evaluation re-ran the *same* `locked` object, each one would
+    # start from the previous run's already-advanced state: the satellites fall
+    # out of lock and later evaluations track almost nothing, collapsing the
+    # reported minimum time and memory to a meaningless (tiny) value. Give each
+    # sample a fresh `deepcopy` of the locked state and pin `evals=1`, so every
+    # measured sample is one honest 45 s forward pass over the full sat set.
+    @benchmarkable(
+        run_process(state, $plan_args, $timed_chunks, NEVER),
+        setup = (state = deepcopy($locked)),
+        evals = 1,
+    )
 end
 
 # ── Benchmark: process with acquisition every 10 sec over RUN_SECONDS ─────
@@ -146,7 +158,16 @@ end
 function bench_process_with_acquisition()
     rs, plan_args = make_receiver_and_plan()
     timed_chunks = CHUNKS[1:N_RUN]
-    @benchmarkable run_process($rs, $plan_args, $timed_chunks, 10u"s")
+    # Same in-place-mutation caveat as above: hand each sample a fresh deepcopy
+    # of the (empty) starting receiver and pin evals=1 so every sample is one
+    # honest 45 s run that acquires and locks from scratch. The acquisition plan
+    # holds only reusable FFT scratch (overwritten each `acquire!`), so it is
+    # shared across samples rather than copied.
+    @benchmarkable(
+        run_process(state, $plan_args, $timed_chunks, 10u"s"),
+        setup = (state = deepcopy($rs)),
+        evals = 1,
+    )
 end
 
 # `receive` consumes (CHUNK × 1) matrix chunks off a `MatrixSizedChannel`, whereas

--- a/src/process.jl
+++ b/src/process.jl
@@ -159,7 +159,16 @@ function update_pvt(
 end
 
 function update_receiver_sat_states(receiver_sat_states, track_state, signal_duration)
-    return map(receiver_sat_states) do receiver_sat_state
+    # In-place `map!` reuses the storage `receiver_sat_states` already owns
+    # instead of `map`, which calls `similar(d)` and allocates a fresh
+    # `Memory{ReceiverSatState}` (~20 KB / frame) every call. Input and output
+    # alias the same dictionary: `map!` reads the old value at each token,
+    # computes the new one, then writes it back at that token, so aliasing is
+    # safe. The immutable `ReceiverSatState` is built in registers and memcpied
+    # into the slot it already occupies — no per-frame heap allocation. Mirrors
+    # the in-place `track!` adopted in c1c8b26; the previous frame's state is
+    # discarded each frame, so mutating in place is not observable downstream.
+    return map!(receiver_sat_states, receiver_sat_states) do receiver_sat_state
         if is_in_lock(receiver_sat_state)
             prn = receiver_sat_state.prn
             ReceiverSatState(


### PR DESCRIPTION
Closes #84. Part of the allocation-reduction effort tracked in #82.

## Problem

`update_receiver_sat_states` (`src/process.jl`) rebuilt the satellite-state dictionary from scratch every 4 ms frame:

```julia
return map(receiver_sat_states) do receiver_sat_state
    ...
end
```

`Dictionaries.map(f, d)` calls `similar(d, T)`, allocating a **fresh `Memory{ReceiverSatState}` of `11 × 1832 B ≈ 20 KB` every frame**, then fills it. This is the single largest steady-state allocator — **74% of per-frame allocations**. The cost is *not* the per-sat work (`decode`, the lock-detector `update`s, `ReceiverSatState` construction all allocate 0 B) and *not* the struct being large per se — it is `map` copying the structs into *freshly allocated* storage each frame.

## Fix

Replace `map` with an in-place `map!(f, d, d)` that reuses the storage the dictionary already owns. Input and output alias the same dictionary: `map!` reads the old value at each token, computes the new one, then writes it back at that token, so the aliasing is safe. The immutable `ReceiverSatState` is built in registers and memcpied into the slot it already occupies — no per-frame heap allocation. The `ReceiverSatState` struct is left exactly as-is (decoder stays embedded by value; no `Ref`, no boxing). Mirrors the in-place `track!` adopted in c1c8b26.

## Empirical allocation (function-barrier `@allocated`, methodology of #82)

Drove `process()` directly over the ION signal (GPSL1CA, 2.048 MHz, 4 ms / 8192-sample frames), warmed 800 frames (3.2 s) to steady state with **11 sats tracked and PVT active**, then measured the isolated `update_receiver_sat_states` call over 20 subsequent frames:

```
sizeof(ReceiverSatState) = 1832 B,  11 sats × 1832 = 20152 B

                              min      median    max
BEFORE  map(f, d)      ->  20232.0    20232.0   20232.0   B/call
AFTER   map!(f, d, d)  ->      0.0        0.0       0.0    B/call
```

**~20 KB/frame eliminated** (74% of steady-state allocation) → ~300 MB less over the 60 s ION run. Numbers are reproducible via the standalone measurement script (drives `process()`, warms past 2 s, function-barrier `@allocated` per frame).

## Acceptance

- `update_receiver_sat_states` allocates **0 B/frame** in steady state (measured above), down from 20232 B.
- Full test suite passes; the ION integration test passes **unchanged** — same 11 healthy PRNs `{5, 7, 8, 13, 15, 18, 20, 21, 24, 28, 30}`, same PVT fix within tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)