### PR TITLE
update_pvt: reuse a SatelliteState buffer, drop the filter→Dictionary (#85)

### DIFF
--- a/src/GNSSReceiver.jl
+++ b/src/GNSSReceiver.jl
@@ -114,11 +114,15 @@ struct ReceiverState{
     TS<:TrackState,
     AB<:SampleBuffer,
     P<:PVTSolution,
+    PB<:AbstractVector{<:SatelliteState},
 }
     track_state::TS
     receiver_sat_states::RS
     acquisition_buffer::AB
     pvt::P
+    # Reused across PVT cycles: `update_pvt` refills this in place each cycle
+    # instead of allocating a fresh `Vector{SatelliteState}` (see `update_pvt`).
+    pvt_sat_state_buffer::PB
     runtime::typeof(1.0u"s")
     last_time_acquisition_ran::typeof(1.0u"s")
     last_time_pvt_ran::typeof(1.0u"s")
@@ -164,11 +168,16 @@ function ReceiverState(
     decoder = GNSSDecoderState(system, 1)
     receiver_sat_states = (Dictionary{Int64,ReceiverSatState{typeof(decoder)}}(),)
     pvt = PositionVelocityTime.PVTSolution()
+    # Preallocated (empty) buffer reused by `update_pvt`. `SatelliteState`'s code
+    # phase / carrier phase are `Float64`; it embeds the decoder by value, so the
+    # element type is pinned to this receiver's decoder and system types.
+    pvt_sat_state_buffer = SatelliteState{Float64,typeof(decoder),typeof(system)}[]
     ReceiverState(
         track_state,
         receiver_sat_states,
         acquisition_buffer,
         pvt,
+        pvt_sat_state_buffer,
         0.0u"s",
         -Inf * 1.0u"s",
         -Inf * 1.0u"s",

--- a/src/process.jl
+++ b/src/process.jl
@@ -2,7 +2,7 @@ get_default_code_lock_cn0_threshold(system::GPSL1CA) = 30.0u"dBHz"
 get_default_code_lock_cn0_threshold(system::GalileoE1B) = 30.0u"dBHz"
 
 function process(
-    receiver_state::ReceiverState{RS,TS,AB,P},
+    receiver_state::ReceiverState{RS,TS,AB,P,PB},
     acq_plan,
     measurement,
     system::AbstractGNSSSignal,
@@ -17,7 +17,7 @@ function process(
     interm_freq = 0.0u"Hz",
     always_buffer = false,
     approximate_year::Integer = year(now(UTC)),
-) where {N,RS,TS,AB,P}
+) where {N,RS,TS,AB,P,PB}
     num_samples = size(measurement, 1)
     signal_duration = num_samples / sampling_freq
     # Currently this only supports a single system. Hence [1]
@@ -78,9 +78,14 @@ function process(
     receiver_sat_states =
         update_receiver_sat_states(receiver_sat_states, track_state, signal_duration)
 
+    # `pvt_sat_state_buffer` is reused (refilled in place) by `update_pvt` and
+    # threaded back into the next ReceiverState, so no fresh SatelliteState
+    # vector is allocated per PVT cycle in steady state.
+    pvt_sat_state_buffer = receiver_state.pvt_sat_state_buffer
     pvt, last_time_pvt_ran = update_pvt(
         system,
         receiver_state.pvt,
+        pvt_sat_state_buffer,
         receiver_sat_states,
         track_state,
         runtime,
@@ -92,11 +97,12 @@ function process(
 
     track_state = filter_in_lock_sats(receiver_sat_states, track_state)
 
-    ReceiverState{RS,TS,AB,P}(
+    ReceiverState{RS,TS,AB,P,PB}(
         track_state,
         (receiver_sat_states,),
         acquisition_buffer,
         pvt,
+        pvt_sat_state_buffer,
         receiver_state.runtime + signal_duration,
         last_time_acquisition_ran,
         last_time_pvt_ran,
@@ -124,6 +130,7 @@ end
 function update_pvt(
     system,
     pvt,
+    pvt_sat_state_buffer,
     receiver_sat_states,
     track_state,
     runtime,
@@ -133,23 +140,29 @@ function update_pvt(
     approximate_year::Integer = year(now(UTC)),
 )
     if runtime - last_time_pvt_ran >= pvt_update_interval
-        receiver_sat_states_ready_for_pvt =
-            filter(receiver_sat_states) do receiver_sat_state
-                is_in_lock(receiver_sat_state) &&
-                    receiver_sat_state.time_in_lock > time_in_lock_before_calculating_pvt
-            end
-
-        pvt_satellite_states =
-            map(receiver_sat_states_ready_for_pvt.values) do receiver_sat_state
-                SatelliteState(
-                    receiver_sat_state.decoder,
-                    system,
-                    get_sat_state(track_state, receiver_sat_state.prn),
+        # Select the PVT-ready satellites and build their `SatelliteState`s in a
+        # single pass, refilling the reused buffer in place. This avoids both the
+        # intermediate filtered `Dictionary{Int,ReceiverSatState}` (which grew from
+        # empty, rehashing the large 1,832-byte structs) and a fresh
+        # `Vector{SatelliteState}` per cycle. `empty!` keeps the buffer's capacity,
+        # so in steady state the refill is allocation-free.
+        empty!(pvt_sat_state_buffer)
+        for receiver_sat_state in receiver_sat_states
+            if is_in_lock(receiver_sat_state) &&
+               receiver_sat_state.time_in_lock > time_in_lock_before_calculating_pvt
+                push!(
+                    pvt_sat_state_buffer,
+                    SatelliteState(
+                        receiver_sat_state.decoder,
+                        system,
+                        get_sat_state(track_state, receiver_sat_state.prn),
+                    ),
                 )
             end
+        end
 
-        if length(pvt_satellite_states) >= 4
-            pvt = calc_pvt(pvt_satellite_states, pvt; approximate_year)
+        if length(pvt_sat_state_buffer) >= 4
+            pvt = calc_pvt(pvt_sat_state_buffer, pvt; approximate_year)
         end
 
         last_time_pvt_ran = runtime

--- a/test/process.jl
+++ b/test/process.jl
@@ -31,11 +31,15 @@
 
     pvt = PositionVelocityTime.PVTSolution()
 
+    decoder = GNSSDecoderState(system, 1)
+    pvt_sat_state_buffer = SatelliteState{Float64,typeof(decoder),typeof(system)}[]
+
     receiver_state = ReceiverState(
         track_state,
         receiver_sat_states,
         acquisition_buffer,
         pvt,
+        pvt_sat_state_buffer,
         0.0u"s",
         -Inf * 1.0u"s",
         -Inf * 1.0u"s",

--- a/test/receive.jl
+++ b/test/receive.jl
@@ -43,11 +43,15 @@
 
     pvt = PositionVelocityTime.PVTSolution()
 
+    decoder = GNSSDecoderState(system, 1)
+    pvt_sat_state_buffer = SatelliteState{Float64,typeof(decoder),typeof(system)}[]
+
     receiver_state = ReceiverState(
         track_state,
         receiver_sat_states,
         acquisition_buffer,
         pvt,
+        pvt_sat_state_buffer,
         0.0u"s",
         -Inf * 1.0u"s",
         -Inf * 1.0u"s",


### PR DESCRIPTION
Closes #85. Part of the allocation-reduction effort tracked in #82.

## Problem

`update_pvt` (`src/process.jl`) runs every `pvt_update_interval` (100 ms → every 25th frame). Each PVT cycle it built:

1. a filtered `Dictionary{Int,ReceiverSatState}` (`filter(pred, receiver_sat_states)`), grown from empty so the 1,832-byte `ReceiverSatState`s were rehashed/realloc-copied several times → **76,896 B**, and
2. a fresh `Vector{SatelliteState}` (`map(...)`), where `SatelliteState` is 1,776 B → **19,656 B**.

`calc_pvt` itself is cheap (128 B). Total: **96,680 B on every 100 ms frame** (~4 KB/frame amortized, a 97 KB spike).

## Change

Select the PVT-ready satellites and construct their `SatelliteState`s in a **single pass**, refilling a **preallocated buffer** in place (`empty!` keeps capacity, then `push!`). No intermediate filtered `Dictionary` and no fresh vector per cycle.

The buffer lives on `ReceiverState` (new `pvt_sat_state_buffer` field, pinned to the receiver's decoder/system types) and is threaded back into the next `ReceiverState`. The receiver already discards the previous `ReceiverState` each chunk (same rationale as the in-place `track!`), so mutating the buffer in place is safe.

## Measured impact

Function-barrier `@allocated` over a **warmed `process()`** driven directly over the ION RTL-SDR signal (GPSL1CA, 2.048 MHz, 4 ms frames), warmed to 4 s so PVT actively computes with **11 PVT-ready sats** — the same methodology as tracking issue #82:

| | B/call | 
|---|--:|
| **before** | **96,680** |
| **after** | **128** |

The remaining 128 B is exactly `calc_pvt`'s inherent allocation; the entire 96,552 B of collection-building is gone (~4 KB/frame amortized removed, and the 97 KB/100 ms spike eliminated).

## Correctness

Full test suite passes, including the ION RTL-SDR integration test (40/40) — identical PVT fix (ECEF position to sub-meter, exact epoch, all 11 healthy sats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)