### PR TITLE
Fix receiver_state boxing in receive (-71% allocation); make process benchmark representative

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,6 @@
 using BenchmarkTools
 using GNSSReceiver
-using GNSSReceiver: ReceiverState, NumAnts, process
+using GNSSReceiver: ReceiverState, NumAnts, process, receive
 using GNSSSignals
 using Unitful
 using Unitful: Hz, ms, s
@@ -149,6 +149,49 @@ function bench_process_with_acquisition()
     @benchmarkable run_process($rs, $plan_args, $timed_chunks, 10u"s")
 end
 
+# `receive` consumes (CHUNK × 1) matrix chunks off a `MatrixSizedChannel`, whereas
+# the direct-`process` benchmarks fold over plain vectors. Materialise the first
+# N_RUN chunks as matrices once, so the timed feed only enqueues them.
+const RECEIVE_CHUNKS = [reshape(c, CHUNK, 1) for c in @view CHUNKS[1:N_RUN]]
+
+make_measurement_channel(chunks) =
+    GNSSReceiver.MatrixSizedChannel{ComplexF32}(CHUNK, 1) do ch
+        for c in chunks
+            put!(ch, c)
+        end
+    end
+
+# Drive the full public `receive` pipeline: a producer task feeds chunks onto the
+# measurement channel, `receive` spawns its own acquisition + tracking task, and the
+# resulting data channel is drained here with a no-op consumer. Unlike the
+# `process`-only benchmarks, this exercises the per-chunk `sat_data` /
+# `ReceiverDataOfInterest` construction and the channel plumbing, so it tracks the
+# receiver's real end-to-end allocation (where the `receiver_state`-boxing fix lands).
+function run_receive(chunks, acquire_every)
+    measurement_channel = make_measurement_channel(chunks)
+    data_channel = receive(
+        measurement_channel,
+        SYSTEM,
+        SAMPLING_FREQ;
+        num_ants = NumAnts(1),
+        acquire_every,
+        acquisition_num_coherent_code_periods = ACQ_CODE_CYCLES,
+        approximate_year = 2017,
+    )
+    GNSSReceiver.consume_channel(_ -> nothing, data_channel)
+    return nothing
+end
+
+# ── Benchmark: full receive() pipeline with acquisition every 10 sec ──────
+# End-to-end analogue of `bench_process_with_acquisition`, but through the public
+# `receive` entry point (channel producer/consumer + spawned tracking task + the
+# per-chunk `sat_data` build) rather than a direct `process` loop. Fresh receiver,
+# re-acquiring every 10 s.
+function bench_receive_with_acquisition()
+    @benchmarkable run_receive($RECEIVE_CHUNKS, 10u"s")
+end
+
 # ── Register benchmarks ───────────────────────────────────────────────────
 SUITE["process without acquisition ($RUN_LABEL)"]["1-ant"] = bench_process_without_acquisition()
 SUITE["process with acquisition every 10 sec ($RUN_LABEL)"]["1-ant"] = bench_process_with_acquisition()
+SUITE["receive with acquisition every 10 sec ($RUN_LABEL)"]["1-ant"] = bench_receive_with_acquisition()

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -114,8 +114,20 @@ end
 # All chunks needed: LOCK_SECONDS of setup followed by RUN_SECONDS of timed run.
 const CHUNKS = load_chunks(N_LOCK + N_RUN)
 
-run_process(rs, plan_args, chunks, acquire_every) =
-    foldl((s, c) -> _process(s, plan_args, c; acquire_every), chunks; init = rs)
+# Drive `process` with a plain reassignment `for` loop rather than `foldl`. This
+# mirrors how `receive` actually calls `process`. It matters for allocation: the
+# `process`/`foldl` combination is fully type-stable (the fold operator infers a
+# concrete return equal to its input), but reaching `process` through `foldl`'s
+# higher-order reduction defeats the optimizer's escape analysis for the immutable
+# temporaries that `Tracking.track!` builds each chunk, so they get heap-allocated
+# (~4x the real allocation). A `for` loop keeps `process` in one frame where those
+# temporaries are elided, matching real-world `receive` behaviour.
+function run_process(rs, plan_args, chunks, acquire_every)
+    for c in chunks
+        rs = _process(rs, plan_args, c; acquire_every)
+    end
+    return rs
+end
 
 # ── Benchmark: process without acquisition over RUN_SECONDS ───────────────
 # Acquire and lock over the first LOCK_SECONDS (setup, not timed), then benchmark

--- a/src/receive.jl
+++ b/src/receive.jl
@@ -59,44 +59,55 @@ function receive(
         SatelliteDataOfInterest{SVector{N,ComplexF64}}
     data_channel = Channel{ReceiverDataOfInterest{sat_data_type}}()
 
+    # Thread `receiver_state` through the per-chunk loop via a *typed* `Ref` rather
+    # than reassigning a captured variable inside the `consume_channel` do-block.
+    # A variable captured by that closure and reassigned would be lowered to an
+    # untyped `Core.Box` (static type `Any`) — `Core.Box` is not parameterised, so it
+    # discards the fact that `receiver_state`'s type never actually changes. Every
+    # `receiver_state.…` access in the per-chunk `sat_data` build would then be a
+    # dynamic, allocating `getproperty` (~71 KB/chunk — the receiver's dominant
+    # allocation). A `Ref{typeof(receiver_state)}` is instead a *typed* cell: it is
+    # captured but never reassigned (only its contents are), so it is not boxed; its
+    # `[]` reads are type-stable; and `[] =` `convert`s to that type, so if `process`
+    # ever returned a different `ReceiverState` type it would error loudly (surfacing
+    # the type-instability regression) instead of silently deoptimising.
+    receiver_state_ref = Ref(receiver_state)
+
     Base.errormonitor(
         Threads.@spawn begin
             try
                 consume_channel(measurement_channel) do measurement
-                    receiver_state = process(
-                    receiver_state,
-                    acq_plan,
-                    num_channels == N == 1 ? vec(measurement) : measurement,
-                    system,
-                    sampling_freq;
-                    downconvert_and_correlator,
-                    num_ants,
-                    acquire_every,
-                    acquisition_false_alarm_probability,
-                    code_lock_cn0_threshold,
-                    time_in_lock_before_calculating_pvt,
-                    pvt_update_interval,
-                    interm_freq,
-                    always_buffer,
-                    approximate_year,
-                )
-                sat_data = Dict{Int,sat_data_type}(
-                    sat_state.prn => SatelliteDataOfInterest(
-                        estimate_cn0(sat_state),
-                        get_prompt(get_last_fully_integrated_correlator(sat_state)),
-                        is_sat_healthy(
-                            receiver_state.receiver_sat_states[1][sat_state.prn].decoder,
-                        ),
-                    ) for sat_state in get_sat_states(receiver_state.track_state)
-                )
-                push!(
-                    data_channel,
-                    ReceiverDataOfInterest(
-                        sat_data,
-                        receiver_state.pvt,
-                        receiver_state.runtime,
-                    ),
-                )
+                    receiver_state_ref[] = process(
+                        receiver_state_ref[],
+                        acq_plan,
+                        num_channels == N == 1 ? vec(measurement) : measurement,
+                        system,
+                        sampling_freq;
+                        downconvert_and_correlator,
+                        num_ants,
+                        acquire_every,
+                        acquisition_false_alarm_probability,
+                        code_lock_cn0_threshold,
+                        time_in_lock_before_calculating_pvt,
+                        pvt_update_interval,
+                        interm_freq,
+                        always_buffer,
+                        approximate_year,
+                    )
+                    rs = receiver_state_ref[]
+                    sat_data = Dict{Int,sat_data_type}(
+                        sat_state.prn => SatelliteDataOfInterest(
+                            estimate_cn0(sat_state),
+                            get_prompt(get_last_fully_integrated_correlator(sat_state)),
+                            is_sat_healthy(
+                                rs.receiver_sat_states[1][sat_state.prn].decoder,
+                            ),
+                        ) for sat_state in get_sat_states(rs.track_state)
+                    )
+                    push!(
+                        data_channel,
+                        ReceiverDataOfInterest(sat_data, rs.pvt, rs.runtime),
+                    )
                 end
             finally
                 close(data_channel)


### PR DESCRIPTION
## What

Two related allocation fixes found while profiling `receive` end-to-end over the 45 s ION integration signal.

### 1. Fix `receiver_state` boxing in `receive` — the receiver's dominant allocator

`receive` reassigned `receiver_state` inside the `consume_channel(measurement_channel) do measurement … end` closure. A variable **captured by a closure and reassigned** is lowered to an untyped `Core.Box` (static type `Any`) — `Core.Box` is not parameterised, so it discards the fact that `receiver_state`'s type is invariant. Every `receiver_state.<field>` access in the per-chunk `sat_data` build then went through a dynamic, allocating `getproperty`.

`Profile.Allocs` on the real `receive()` attributed ~71 KB of the ~100 KB allocated per 4 ms chunk to this (`getproperty` + `ijl_new_bits` scalar boxing) — the single largest allocator, well ahead of anything inside `process`.

**Fix:** thread `receiver_state` through a typed `Ref`. The Ref is captured but never reassigned (only its contents are), so it is not boxed; `[]` reads are type-stable, so the `sat_data` field accesses are free; and `[] =` `convert`s to the stored type, so if `process` ever returned a different `ReceiverState` type it errors loudly (surfacing the regression) rather than silently deoptimising.

| `receive()` over 45 s | allocation |
|:--|--:|
| before | ~1083 MiB |
| after | **~317 MiB (−71%)** |

### 2. Drive `process` with a `for`-loop, not `foldl`, in the process benchmarks

The `process` benchmarks reported ~4× their real allocation (e.g. **1189 MiB** vs ~300 MiB for the 45 s *with acquisition* case). `run_process` drove `process` with `Base.foldl`. Reaching `process` through foldl's higher-order reduction is fully type-stable (the fold operator infers a concrete return equal to its input; `@inferred` passes) but **defeats the optimizer's escape analysis** for the immutable temporaries `Tracking.track!` builds each chunk, so they get heap-allocated instead of elided. A plain reassignment `for` loop — which is how `receive` actually calls `process` — keeps them elided.

The benchmark now reports figures representative of the real receiver (~292 MiB *with* acquisition, ~270 MiB *without*) instead of the foldl-inflated ~1189 MiB.

## Testing

- Full test suite passes; the ION RTL-SDR integration test passes **unchanged** — same 11 healthy PRNs `{5, 7, 8, 13, 15, 18, 20, 21, 24, 28, 30}`, same PVT fix within tolerances (and it runs noticeably faster from the reduced GC pressure).
- `receive()` allocation measured end-to-end with a preloaded-chunk producer + `@allocated` (harness reproductions of the boxing are fragile, so it was verified only against the real `receive`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 3. Add an end-to-end `receive()` allocation benchmark

The existing benchmarks measure `process` only — which fix #1 doesn't touch — so they don't reflect the win. Added a `receive with acquisition every 10 sec` benchmark driving the full public `receive` pipeline (channel producer/consumer + spawned tracking task + the per-chunk `sat_data` build), so the receiver's real end-to-end allocation is guarded in CI. It reports ~317 MiB on this branch vs the ~1083 MiB removed by fix #1. (Adapted from the `receive` benchmark in #89, in `MatrixSizedChannel` form.)
