### PR TITLE
Use Dictionaries.Dictionary for user-facing sat_data

### DIFF
--- a/src/gui.jl
+++ b/src/gui.jl
@@ -2,7 +2,7 @@ using UnicodePlots, Term
 import REPL
 
 struct GUIData{S<:SatelliteDataOfInterest}
-    sat_data::Dict{Int,S}
+    sat_data::Dictionary{Int,S}
     pvt::PVTSolution
     runtime::typeof(1.0u"s")
 end
@@ -86,15 +86,19 @@ function gui(gui_data_channel, io::IO = stdout; construct_gui_panels = construct
 end
 
 function construct_gui_panels(gui_data, num_dots)
-    prn_strings = string.(keys(gui_data.sat_data))
+    # `sat_data` is a Dictionaries.Dictionary; collect its keys/values to plain
+    # Vectors (as with `pvt.sats` below) so UnicodePlots gets vectors and the
+    # three arrays stay index-aligned.
+    prn_strings = string.(collect(keys(gui_data.sat_data)))
+    sat_values = collect(values(gui_data.sat_data))
     cn0s = map(
         x -> round(
             10 * log10(linear(x.cn0 == (Inf)u"Hz" ? 1u"Hz" : x.cn0) / u"Hz");
             digits = 1,
         ),
-        values(gui_data.sat_data),
+        sat_values,
     )
-    colors = map(x -> x.is_healthy ? :green : :red, values(gui_data.sat_data))
+    colors = map(x -> x.is_healthy ? :green : :red, sat_values)
     pvt = gui_data.pvt
     sat_doa_panel_title = "Satellite Direction-of-Arrival (DOA)"
     position_panel_title = "User position"

--- a/src/receive.jl
+++ b/src/receive.jl
@@ -5,7 +5,7 @@ struct SatelliteDataOfInterest{P<:Union{<:Complex,<:AbstractVector{<:Complex}}}
 end
 
 struct ReceiverDataOfInterest{S<:SatelliteDataOfInterest}
-    sat_data::Dict{Int,S}
+    sat_data::Dictionary{Int,S}
     pvt::PVTSolution
     runtime::typeof(1.0u"s")
 end
@@ -125,13 +125,17 @@ function receive(
                 approximate_year,
             )
             rs = receiver_state_ref[]
-            sat_data = Dict{Int,sat_data_type}(
-                sat_state.prn => SatelliteDataOfInterest(
+            # Tracking's `get_sat_states` is a `Dictionary` keyed by PRN, so `map`
+            # over it keeps those PRN keys and only transforms each satellite into
+            # the data of interest — no keys to rebuild, and the result is already
+            # the `Dictionary{Int,sat_data_type}` the channel expects.
+            sat_data = map(get_sat_states(rs.track_state)) do sat_state
+                SatelliteDataOfInterest(
                     estimate_cn0(sat_state),
                     get_prompt(get_last_fully_integrated_correlator(sat_state)),
                     is_sat_healthy(rs.receiver_sat_states[1][sat_state.prn].decoder),
-                ) for sat_state in get_sat_states(rs.track_state)
-            )
+                )
+            end
             put!(data_channel, ReceiverDataOfInterest(sat_data, rs.pvt, rs.runtime))
         end
         close(data_channel)

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -3,12 +3,13 @@
     data_channel = Channel{GNSSReceiver.ReceiverDataOfInterest{sat_data_type}}() do ch
         foreach(1:100) do i
             data = GNSSReceiver.ReceiverDataOfInterest{sat_data_type}(
-                Dict{Int,sat_data_type}(
-                    1 => sat_data_type(
+                Dictionary(
+                    [1],
+                    [sat_data_type(
                         45.0dBHz,
                         SVector(complex(1.0, 2.0), complex(2.0, 3.0)),
                         true,
-                    ),
+                    )],
                 ),
                 GNSSReceiver.PVTSolution(),
                 (i - 1) * 0.004u"s",
@@ -32,7 +33,7 @@ end
     gui_data_channel = Channel{GNSSReceiver.GUIData}() do ch
         sat_data_type = GNSSReceiver.SatelliteDataOfInterest{SVector{2,ComplexF64}}
         gui_data = GNSSReceiver.GUIData(
-            Dict{Int,sat_data_type}(),
+            Dictionary{Int,sat_data_type}(),
             GNSSReceiver.PVTSolution(),
             0.0u"s",
         )
@@ -51,27 +52,30 @@ end
     sat_data_type = GNSSReceiver.SatelliteDataOfInterest{SVector{2,ComplexF64}}
     gui_data_channel = Channel{GNSSReceiver.GUIData}() do ch
         gui_data = GNSSReceiver.GUIData(
-            Dict{Int,sat_data_type}(
-                3 => GNSSReceiver.SatelliteDataOfInterest(
-                    46.3453dBHz,
-                    zeros(SVector{2,ComplexF64}),
-                    true,
-                ),
-                12 => GNSSReceiver.SatelliteDataOfInterest(
-                    42.233dBHz,
-                    zeros(SVector{2,ComplexF64}),
-                    true,
-                ),
-                23 => GNSSReceiver.SatelliteDataOfInterest(
-                    43.23123dBHz,
-                    zeros(SVector{2,ComplexF64}),
-                    true,
-                ),
-                10 => GNSSReceiver.SatelliteDataOfInterest(
-                    45.123467dBHz,
-                    zeros(SVector{2,ComplexF64}),
-                    true,
-                ),
+            Dictionary(
+                [3, 12, 23, 10],
+                [
+                    GNSSReceiver.SatelliteDataOfInterest(
+                        46.3453dBHz,
+                        zeros(SVector{2,ComplexF64}),
+                        true,
+                    ),
+                    GNSSReceiver.SatelliteDataOfInterest(
+                        42.233dBHz,
+                        zeros(SVector{2,ComplexF64}),
+                        true,
+                    ),
+                    GNSSReceiver.SatelliteDataOfInterest(
+                        43.23123dBHz,
+                        zeros(SVector{2,ComplexF64}),
+                        true,
+                    ),
+                    GNSSReceiver.SatelliteDataOfInterest(
+                        45.123467dBHz,
+                        zeros(SVector{2,ComplexF64}),
+                        true,
+                    ),
+                ],
             ),
             PositionVelocityTime.PVTSolution(;
                 position = ECEF(4.0e6, 3.9e5, 4.9e6),

--- a/test/ion_rtlsdr_integration.jl
+++ b/test/ion_rtlsdr_integration.jl
@@ -102,7 +102,7 @@ let
         GNSSReceiver.consume_channel(data_channel) do data
             num_sats = length(data.sat_data)
             max_sats_seen = max(max_sats_seen, num_sats)
-            for (prn, sd) in data.sat_data
+            for (prn, sd) in pairs(data.sat_data)
                 push!(acquired_prns, prn)
                 if sd.is_healthy
                     push!(healthy_prns, prn)

--- a/test/save_data.jl
+++ b/test/save_data.jl
@@ -3,7 +3,7 @@
     data_channel = Channel{GNSSReceiver.ReceiverDataOfInterest{sat_data_type}}() do ch
         foreach(1:20) do i
             data = GNSSReceiver.ReceiverDataOfInterest{sat_data_type}(
-                Dict{Int,Vector{sat_data_type}}(),
+                Dictionary{Int,sat_data_type}(),
                 GNSSReceiver.PVTSolution(),
                 (i - 1) * 1ms,
             )


### PR DESCRIPTION
## What

Finishes the `Dictionaries.jl` migration by converting the last two plain `Dict`s — the user-facing `sat_data` fields of `ReceiverDataOfInterest` (`src/receive.jl`) and `GUIData` (`src/gui.jl`) — to `Dictionaries.Dictionary`.

The receiver internals (`receiver_sat_states`, PVT's `sats`, `ReceiverState`) already use `Dictionaries.jl` to match Tracking's containers; `sat_data` was the only holdout.

## Why

Tracking's `get_sat_states` returns a `Dictionary{Int,TrackedSat}` keyed by PRN. With `sat_data` now a `Dictionary`, building it collapses to a plain `map` over `get_sat_states` (keeping the PRN keys) instead of a `Dict` generator comprehension — simpler, type-stable, and allocation-friendly for the `receive` hot loop.

## Changes

- `src/receive.jl`: `sat_data::Dict{Int,S}` → `Dictionary{Int,S}`; construction is now `map(get_sat_states(...))`.
- `src/gui.jl`: `sat_data::Dict{Int,S}` → `Dictionary{Int,S}`; barplot construction `collect`s keys/values to `Vector`s for UnicodePlots (matching the existing `pvt.sats` handling).
- Tests: `Dict{...}(...)` literals → `Dictionary(...)`; integration test iterates `pairs(sat_data)` (iterating a `Dictionary` yields values, not pairs).

## Testing

Local `gui`, `save_data`, `receive`, `process`, `beamformer` test sets pass (267 tests, 0 failures). The `receive` tests exercise the `map`-based construction end-to-end. The `ion_rtlsdr_integration` set (246 MB download) was not run locally; its only change is the `pairs()` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)