### PR TITLE
docs: note functional sat-set mutators are load-bearing for sat_data safety

### DIFF
--- a/src/process.jl
+++ b/src/process.jl
@@ -122,6 +122,18 @@ function filter_in_lock_sats(receiver_sat_states, track_state)
 
     # Tracking v3 dropped `filter_out_sats`; remove PRNs one at a time,
     # threading the returned TrackState through each removal.
+    #
+    # Use the *functional* `remove_satellite` (and, in the acquisition path,
+    # `merge_sats`), NOT the in-place `remove_satellite!` / `add_satellite!`.
+    # `receive` builds the user-facing `sat_data` with `map(get_sat_states(...))`,
+    # and Dictionaries' `map` *shares the source's key `Indices` object* with the
+    # emitted payload (only the values vector is fresh). Those payloads then sit in
+    # `data_channel` and are re-forwarded downstream (e.g. into `GUIData`), so the
+    # previous chunk's key set is still referenced elsewhere. The functional
+    # mutators build a *fresh* `Dictionary`, leaving that shared `Indices`
+    # untouched; the in-place `!` variants would mutate it and retroactively
+    # corrupt every in-flight payload sharing it (its keys and values vectors would
+    # disagree in length → `BoundsError` when a consumer iterates it).
     foldl(prns_to_remove; init = track_state) do ts, prn
         remove_satellite(ts; prn)
     end

--- a/src/receive.jl
+++ b/src/receive.jl
@@ -129,6 +129,14 @@ function receive(
             # over it keeps those PRN keys and only transforms each satellite into
             # the data of interest — no keys to rebuild, and the result is already
             # the `Dictionary{Int,sat_data_type}` the channel expects.
+            #
+            # Note: `map` *shares* the source's key `Indices` with this payload
+            # (only the values vector is fresh), and the payload outlives this
+            # iteration (it queues in `data_channel` and is re-forwarded downstream).
+            # This is safe only because `process` mutates the sat set exclusively
+            # through the functional `remove_satellite` / `merge_sats`, which build a
+            # fresh `Dictionary` rather than mutating the shared `Indices` in place.
+            # See the load-bearing comment in `filter_in_lock_sats` (process.jl).
             sat_data = map(get_sat_states(rs.track_state)) do sat_state
                 SatelliteDataOfInterest(
                     estimate_cn0(sat_state),


### PR DESCRIPTION
## What

Adds explanatory comments (no code change) at two sites:

- **`process.jl` — `filter_in_lock_sats`** (the `remove_satellite` call, runs every chunk)
- **`receive.jl` — the `map(get_sat_states(...))` sat_data build**

## Why

`receive` builds the user-facing `sat_data` with `map` over `get_sat_states(...)`. Dictionaries.jl's `map` **shares the source's key `Indices`** with the emitted payload (only the values vector is fresh). Those payloads outlive the chunk — they queue in `data_channel` and are re-forwarded downstream (e.g. into `GUIData`, held while the GUI renders) — so the previous chunk's key set stays referenced elsewhere.

This is safe **only** because `process` changes the tracked-satellite set exclusively through the *functional* `Tracking.remove_satellite` / `merge_sats`, which build a fresh `Dictionary` and leave the shared `Indices` untouched. The in-place `remove_satellite!` / `add_satellite!` variants would mutate that `Indices` and retroactively corrupt every in-flight payload sharing it (its keys and values vectors would disagree in length → `BoundsError` when a consumer iterates it).

The comment records this invariant so a future allocation-minded change doesn't silently swap in the `!` variants.

## Context

Came out of benchmarking the `receive`-vs-`process` steady-state discrepancy: the gap is ~10% (a small per-chunk `sat_data` build + channel handoff), not worth optimizing, but the shared-key aliasing was a real latent footgun worth documenting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)