### PR TITLE
Make lock detectors track elapsed signal time

### DIFF
--- a/src/lock_detector.jl
+++ b/src/lock_detector.jl
@@ -4,6 +4,11 @@
 Supertype for the receiver's per-satellite lock detectors. A concrete detector is
 advanced with `update` and queried with [`is_in_lock`](@ref); a satellite is treated
 as locked only while both its code and carrier detectors report lock.
+
+The detectors track elapsed signal time rather than a number of `update` calls, so
+their behaviour is independent of how the incoming signal is chunked: each `update`
+is handed the `signal_duration` it represents and accumulates that duration into its
+timers.
 """
 abstract type AbstractLockDetector end
 
@@ -11,88 +16,99 @@ abstract type AbstractLockDetector end
     CodeLockDetector <: AbstractLockDetector
 
 Declares code lock from the estimated carrier-to-noise density ratio. After a
-`wait_counter_threshold`-update warm-up it increments an out-of-lock counter each time
-the CN0 is below `cn0_threshold` (and decrements it otherwise); lock is lost once that
-counter reaches `num_out_of_lock_threshold`.
+`wait_time_threshold` warm-up it accumulates out-of-lock time whenever the CN0 is below
+`cn0_threshold` (and pays it back down otherwise); lock is lost once the accumulated
+out-of-lock time reaches `out_of_lock_time_threshold`.
 """
 struct CodeLockDetector <: AbstractLockDetector
     cn0_threshold::typeof(1.0u"dBHz")
-    num_out_of_lock::Int
-    num_out_of_lock_threshold::Int
-    wait_counter_threshold::Int
-    wait_counter::Int
+    out_of_lock_time::typeof(1.0u"s")
+    out_of_lock_time_threshold::typeof(1.0u"s")
+    wait_time::typeof(1.0u"s")
+    wait_time_threshold::typeof(1.0u"s")
 end
 
 function CodeLockDetector(;
     cn0_threshold = 30u"dBHz",
-    num_out_of_lock_threshold = 50,
-    wait_counter_threshold = 20,
+    out_of_lock_time_threshold = 200u"ms",
+    wait_time_threshold = 80u"ms",
 )
-    CodeLockDetector(cn0_threshold, 0, num_out_of_lock_threshold, wait_counter_threshold, 0)
+    CodeLockDetector(
+        cn0_threshold,
+        0.0u"s",
+        out_of_lock_time_threshold,
+        0.0u"s",
+        wait_time_threshold,
+    )
 end
 
-function update(lock_detector::CodeLockDetector, cn0)
-    num_out_of_lock = lock_detector.num_out_of_lock
-    if lock_detector.wait_counter + 1 > lock_detector.wait_counter_threshold
+function update(lock_detector::CodeLockDetector, cn0, signal_duration)
+    out_of_lock_time = lock_detector.out_of_lock_time
+    if lock_detector.wait_time >= lock_detector.wait_time_threshold
         if cn0 < lock_detector.cn0_threshold
-            num_out_of_lock += 1
-        elseif num_out_of_lock > 0
-            num_out_of_lock -= 1
+            out_of_lock_time += signal_duration
+        elseif out_of_lock_time > 0.0u"s"
+            out_of_lock_time -= signal_duration
         end
     end
     CodeLockDetector(
         lock_detector.cn0_threshold,
-        num_out_of_lock,
-        lock_detector.num_out_of_lock_threshold,
-        lock_detector.wait_counter_threshold,
-        min(lock_detector.wait_counter + 1, lock_detector.wait_counter_threshold),
+        out_of_lock_time,
+        lock_detector.out_of_lock_time_threshold,
+        min(lock_detector.wait_time + signal_duration, lock_detector.wait_time_threshold),
+        lock_detector.wait_time_threshold,
     )
 end
 
 """
     is_in_lock(lock_detector::AbstractLockDetector)
 
-Return `true` while the detector's out-of-lock counter is below its threshold.
+Return `true` while the detector's accumulated out-of-lock time is below its threshold.
 """
 function is_in_lock(lock_detector::AbstractLockDetector)
-    lock_detector.num_out_of_lock < lock_detector.num_out_of_lock_threshold
+    lock_detector.out_of_lock_time < lock_detector.out_of_lock_time_threshold
 end
 
 """
     CarrierLockDetector <: AbstractLockDetector
 
 Declares carrier lock from the prompt correlator using the standard low-pass filtered
-in-phase/quadrature amplitude test. Over each 20-integration block it compares the
-filtered in-phase amplitude against the filtered quadrature amplitude; too little
-in-phase dominance increments the out-of-lock counter, and lock is lost once it reaches
-`num_out_of_lock_threshold`.
+in-phase/quadrature amplitude test. Over each `integration_time_threshold` block it
+compares the filtered in-phase amplitude against the filtered quadrature amplitude; too
+little in-phase dominance accumulates out-of-lock time, and lock is lost once it reaches
+`out_of_lock_time_threshold`.
 """
 struct CarrierLockDetector <: AbstractLockDetector
     prev_filtered_inphase::Float64
     prev_filtered_quadrature::Float64
-    integration_counter::Int
-    num_out_of_lock::Int
-    num_out_of_lock_threshold::Int
-    wait_counter_threshold::Int
-    wait_counter::Int
+    integration_time::typeof(1.0u"s")
+    integration_time_threshold::typeof(1.0u"s")
+    out_of_lock_time::typeof(1.0u"s")
+    out_of_lock_time_threshold::typeof(1.0u"s")
+    wait_time::typeof(1.0u"s")
+    wait_time_threshold::typeof(1.0u"s")
 end
 
-function CarrierLockDetector(num_out_of_lock_threshold = 50, wait_counter_threshold = 20)
+function CarrierLockDetector(;
+    out_of_lock_time_threshold = 4u"s",
+    wait_time_threshold = 80u"ms",
+    integration_time_threshold = 80u"ms",
+)
     CarrierLockDetector(
         0.0,
         0.0,
-        0,
-        0,
-        num_out_of_lock_threshold,
-        wait_counter_threshold,
-        0,
+        0.0u"s",
+        integration_time_threshold,
+        0.0u"s",
+        out_of_lock_time_threshold,
+        0.0u"s",
+        wait_time_threshold,
     )
 end
 
-function update(lock_detector::CarrierLockDetector, prompt)
+function update(lock_detector::CarrierLockDetector, prompt, signal_duration)
     K1 = 0.0247
     K2 = 1.5
-    integration_counter_threshold = 20
     next_filtered_inphase =
         (abs(real(prompt)) - lock_detector.prev_filtered_inphase) * K1 +
         lock_detector.prev_filtered_inphase
@@ -100,25 +116,28 @@ function update(lock_detector::CarrierLockDetector, prompt)
         (abs(imag(prompt)) - lock_detector.prev_filtered_quadrature) * K1 +
         lock_detector.prev_filtered_quadrature
 
-    num_out_of_lock = lock_detector.num_out_of_lock
-    if lock_detector.integration_counter + 1 == integration_counter_threshold
-        if lock_detector.wait_counter + 1 > lock_detector.wait_counter_threshold
+    out_of_lock_time = lock_detector.out_of_lock_time
+    next_integration_time = lock_detector.integration_time + signal_duration
+    if next_integration_time >= lock_detector.integration_time_threshold
+        if lock_detector.wait_time >= lock_detector.wait_time_threshold
             if next_filtered_inphase / K2 < next_filtered_quadrature
-                num_out_of_lock += 1
+                out_of_lock_time += next_integration_time
             else
-                num_out_of_lock = 0
+                out_of_lock_time = 0.0u"s"
             end
         end
         next_filtered_inphase = 0.0
         next_filtered_quadrature = 0.0
+        next_integration_time = 0.0u"s"
     end
     CarrierLockDetector(
         next_filtered_inphase,
         next_filtered_quadrature,
-        mod(lock_detector.integration_counter + 1, integration_counter_threshold),
-        num_out_of_lock,
-        lock_detector.num_out_of_lock_threshold,
-        lock_detector.wait_counter_threshold,
-        min(lock_detector.wait_counter + 1, lock_detector.wait_counter_threshold),
+        next_integration_time,
+        lock_detector.integration_time_threshold,
+        out_of_lock_time,
+        lock_detector.out_of_lock_time_threshold,
+        min(lock_detector.wait_time + signal_duration, lock_detector.wait_time_threshold),
+        lock_detector.wait_time_threshold,
     )
 end

--- a/src/process.jl
+++ b/src/process.jl
@@ -223,10 +223,12 @@ function update_receiver_sat_states(receiver_sat_states, track_state, signal_dur
                 update(
                     receiver_sat_state.code_lock_detector,
                     estimate_cn0(track_state, prn),
+                    signal_duration,
                 ),
                 update(
                     receiver_sat_state.carrier_lock_detector,
                     get_last_fully_integrated_filtered_prompt(track_state, prn),
+                    signal_duration,
                 ),
                 receiver_sat_state.time_in_lock + signal_duration,
                 0.0u"s",


### PR DESCRIPTION
Targets `main` (previously stacked on #98, now merged).

## What

The code and carrier lock detectors previously counted `update` calls (frames) rather than elapsed time. Since `update` fires once per processed signal chunk, the wall-clock meaning of each threshold depended on how the incoming signal was chunked: "50 frames" was 50 ms at a 1 ms chunk but 200 ms at the 4 ms chunk the receiver actually uses (`num_samples_to_receive = sampling_freq * 4u"ms"`).

This PR parameterises both detectors in physical time. Each `update` now receives the `signal_duration` it represents and accumulates it into the out-of-lock, warm-up, and integration timers, so detector behaviour is independent of chunking.

## Changes

- `CodeLockDetector` / `CarrierLockDetector` fields are now `Unitful` times (`u"s"`) instead of integer counters.
- `update(detector, measurement, signal_duration)` gains the `signal_duration` argument; the two call sites in `process.jl` pass the frame's `signal_duration` (already in scope).
- The carrier integration window is now a configurable `integration_time_threshold` field rather than a hard-coded count of 20.

## Behaviour

Defaults are chosen to preserve current behaviour at the receiver's 4 ms chunk size:

| Detector | out-of-lock | warm-up | other |
|---|---|---|---|
| Code | 200 ms | 80 ms | CN0 threshold 30 dBHz |
| Carrier | 4 s | 80 ms | integration window 80 ms |

Verified with a standalone sanity check (code drops lock after 280 ms = 80 ms warm-up + 50×4 ms; carrier after 4080 ms = 80 ms + 50×80 ms blocks) and the full `Pkg.test()` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)