### PR TITLE
test: cover reacquisition, lock detectors, and other missing coverage

### DIFF
--- a/test/gui.jl
+++ b/test/gui.jl
@@ -5,11 +5,13 @@
             data = GNSSReceiver.ReceiverDataOfInterest{sat_data_type}(
                 Dictionary(
                     [1],
-                    [sat_data_type(
-                        45.0dBHz,
-                        SVector(complex(1.0, 2.0), complex(2.0, 3.0)),
-                        true,
-                    )],
+                    [
+                        sat_data_type(
+                            45.0dBHz,
+                            SVector(complex(1.0, 2.0), complex(2.0, 3.0)),
+                            true,
+                        ),
+                    ],
                 ),
                 GNSSReceiver.PVTSolution(),
                 (i - 1) * 0.004u"s",
@@ -111,4 +113,33 @@ end
     @test occursin("46.3", out)
     @test occursin("50.830894797269906", out)
     @test occursin("5.568737077976637", out)
+end
+
+@testset "GUI while decoding (enough sats but no PVT yet)" begin
+    sat_data_type = GNSSReceiver.SatelliteDataOfInterest{SVector{2,ComplexF64}}
+    gui_data_channel = Channel{GNSSReceiver.GUIData}() do ch
+        gui_data = GNSSReceiver.GUIData(
+            Dictionary(
+                [3, 12, 23, 10],
+                [
+                    GNSSReceiver.SatelliteDataOfInterest(
+                        45.0dBHz,
+                        zeros(SVector{2,ComplexF64}),
+                        true,
+                    ) for _ = 1:4
+                ],
+            ),
+            GNSSReceiver.PVTSolution(),  # no fix yet: pvt.time === nothing
+            10.0u"s",
+        )
+        foreach(i -> put!(ch, gui_data), 1:20)
+    end
+
+    buf = IOBuffer()
+    GNSSReceiver.gui(gui_data_channel, buf)
+    out = String(take!(buf))
+    # Four tracked sats show up in the CN0 barplot, but with no PVT fix the DOA and
+    # position panels report that decoding is still in progress.
+    @test occursin("Decoding satellites", out)
+    @test !occursin("Not enough satellites", out)
 end

--- a/test/ion_rtlsdr_integration.jl
+++ b/test/ion_rtlsdr_integration.jl
@@ -37,6 +37,42 @@ function _ion_produce!(ch, ::Type{T}, dat_file, num_samples, num_ants) where {T}
     end
 end
 
+# Like `_ion_produce!`, but drops `slip_samples` samples right after `slip_after_chunk`
+# chunks (shifting the rest of the stream by that many samples) and stops after
+# `stop_after_chunk` chunks. Used to force a mid-stream timing slip so the tracking
+# loops lose lock and the receiver has to reacquire.
+function _ion_produce_with_slip!(
+    ch,
+    ::Type{T},
+    dat_file,
+    num_samples,
+    num_ants;
+    slip_after_chunk,
+    slip_samples,
+    stop_after_chunk,
+) where {T}
+    io = open(dat_file)
+    raw_buf = Vector{UInt8}(undef, 2 * num_samples)
+    slip_buf = Vector{UInt8}(undef, 2 * slip_samples)
+    try
+        chunk_i = 0
+        while !eof(io)
+            n = readbytes!(io, raw_buf)
+            n < 2 * num_samples && break
+            chunk = Matrix{T}(undef, num_samples, num_ants)
+            @inbounds for i = 1:num_samples
+                chunk[i, 1] = _ion_sample(T, raw_buf[2i-1], raw_buf[2i])
+            end
+            put!(ch, chunk)
+            chunk_i += 1
+            chunk_i == slip_after_chunk && readbytes!(io, slip_buf)
+            chunk_i >= stop_after_chunk && break
+        end
+    finally
+        close(io)
+    end
+end
+
 # ION SDR sample data: 2.048 MS/s, 8-bit unsigned offset-binary I/Q, 60 s, GPS L1.
 # Source:  https://sdr.ion.org/api-sample-data.html
 # Ground truth (publisher's PRN list): {5, 13, 15, 20, 21, 28, 30}.
@@ -59,7 +95,7 @@ let
     # backend for `ComplexF32` and Tracking's fast integer backend for
     # `Complex{Int16}`; both must reach the same fix on the same recording.
     @testset "ION RTL-SDR signal integration test ($type)" for type in
-                                                                [ComplexF32, Complex{Int16}]
+                                                               [ComplexF32, Complex{Int16}]
         sampling_freq = 2.048e6u"Hz"
         system = GPSL1CA()
         # 4 ms chunks = 8192 samples at 2.048 MHz
@@ -67,10 +103,9 @@ let
         num_ants = 1
         expected_prns = Set([5, 13, 15, 20, 21, 28, 30])
 
-        measurement_channel =
-            GNSSReceiver.SignalChannel{type,num_ants}(num_samples) do ch
-                _ion_produce!(ch, type, dat_file, num_samples, num_ants)
-            end
+        measurement_channel = GNSSReceiver.SignalChannel{type,num_ants}(num_samples) do ch
+            _ion_produce!(ch, type, dat_file, num_samples, num_ants)
+        end
 
         # 10 ms coherent integration (`acquisition_num_coherent_code_periods = 10`) with
         # the v2 acquisition (`plan_acquire` + CFAR detection) locks the full healthy
@@ -150,8 +185,17 @@ let
         expected_vdop = 1.13
         expected_tdop = 0.72
         expected_cn0_dbhz = Dict(
-            5 => 51.2, 7 => 41.9, 8 => 40.8, 13 => 46.9, 15 => 48.5,
-            18 => 40.8, 20 => 44.1, 21 => 41.9, 24 => 40.2, 28 => 49.4, 30 => 49.1,
+            5 => 51.2,
+            7 => 41.9,
+            8 => 40.8,
+            13 => 46.9,
+            15 => 48.5,
+            18 => 40.8,
+            20 => 44.1,
+            21 => 41.9,
+            24 => 40.2,
+            28 => 49.4,
+            30 => 49.1,
         )
 
         # Position: 1 m tolerance (LSQ + ephemeris noise is sub-mm; tolerance
@@ -174,7 +218,11 @@ let
 
         # Receiver clock bias and drift
         @test isapprox(last_pvt.time_correction, expected_time_correction, rtol = 1e-4)
-        @test isapprox(last_pvt.relative_clock_drift, expected_relative_clock_drift, rtol = 0.05)
+        @test isapprox(
+            last_pvt.relative_clock_drift,
+            expected_relative_clock_drift,
+            rtol = 0.05,
+        )
 
         # DOPs depend only on satellite geometry; reproducible to ~1%.
         @test isapprox(last_pvt.dop.GDOP, expected_gdop, rtol = 0.05)
@@ -194,5 +242,63 @@ let
             cn0_dbhz = ustrip(last_sat_data[prn].cn0)
             @test isapprox(cn0_dbhz, expected_dbhz, atol = 2.0)
         end
+    end
+
+    # Drive the reacquisition path with the real recording: once the full set is
+    # locked, drop a few samples so the code phase slips out of the correlator's
+    # pull-in range. Satellites lose lock and the receiver reacquires them (a single
+    # dropped sample is only a ~0.5-chip step the DLL absorbs, and a full 2048-sample
+    # code period would realign exactly — a ~1.5-chip, 3-sample slip reliably knocks
+    # them out).
+    @testset "Reacquisition after a mid-stream sample slip" begin
+        sampling_freq = 2.048e6u"Hz"
+        system = GPSL1CA()
+        num_samples = Int(upreferred(sampling_freq * 4u"ms"))
+        # Slip ~6 s in (well after the full set is locked) and stop ~8.8 s in — before
+        # the 10 s periodic acquisition, so any recovery is via reacquisition of the
+        # lost satellites rather than the periodic full search.
+        slip_after_chunk = 1500
+        stop_after_chunk = 2200
+
+        measurement_channel = GNSSReceiver.SignalChannel{ComplexF32,1}(num_samples) do ch
+            _ion_produce_with_slip!(
+                ch,
+                ComplexF32,
+                dat_file,
+                num_samples,
+                1;
+                slip_after_chunk,
+                slip_samples = 3,
+                stop_after_chunk,
+            )
+        end
+
+        data_channel = receive(
+            measurement_channel,
+            system,
+            sampling_freq;
+            num_ants = NumAnts(1),
+            interm_freq = 0.0u"Hz",
+            acquisition_num_coherent_code_periods = 10,
+            approximate_year = 2017,
+            max_meas = 2^7,
+        )
+
+        sat_counts = Int[]
+        GNSSReceiver.consume_channel(data_channel) do data
+            push!(sat_counts, length(data.sat_data))
+        end
+
+        before_slip = sat_counts[1:slip_after_chunk]
+        after_slip = sat_counts[(slip_after_chunk+1):end]
+        @info "Reacquisition slip" locked_before = maximum(before_slip) min_after =
+            minimum(after_slip) final = sat_counts[end]
+
+        # The full healthy set is locked before the slip.
+        @test maximum(before_slip) == 11
+        # The slip knocks satellites out of lock (they are removed from the track state).
+        @test minimum(after_slip) < maximum(before_slip)
+        # Reacquisition brings satellites back before the run ends.
+        @test sat_counts[end] > minimum(after_slip)
     end
 end

--- a/test/lock_detector.jl
+++ b/test/lock_detector.jl
@@ -1,0 +1,63 @@
+@testset "CodeLockDetector accumulates and pays back out-of-lock time" begin
+    # Warm up past the wait-time threshold with a healthy CN0 so the detector
+    # starts arming its out-of-lock timer.
+    detector = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30u"dBHz",
+        out_of_lock_time_threshold = 200u"ms",
+        wait_time_threshold = 80u"ms",
+    )
+    for _ = 1:20
+        detector = GNSSReceiver.update(detector, 45u"dBHz", 4u"ms")
+    end
+    @test GNSSReceiver.is_in_lock(detector)
+    @test detector.out_of_lock_time == 0u"s"
+
+    # CN0 below threshold accumulates out-of-lock time until lock is declared lost.
+    for _ = 1:60
+        detector = GNSSReceiver.update(detector, 10u"dBHz", 4u"ms")
+    end
+    @test !GNSSReceiver.is_in_lock(detector)
+    @test detector.out_of_lock_time >= 200u"ms"
+
+    # A healthy CN0 again pays the accumulated out-of-lock time back down.
+    accumulated = detector.out_of_lock_time
+    detector = GNSSReceiver.update(detector, 45u"dBHz", 4u"ms")
+    @test detector.out_of_lock_time < accumulated
+    @test detector.out_of_lock_time == accumulated - 4u"ms"
+end
+
+@testset "CodeLockDetector stays neutral before the wait time elapses" begin
+    # Before `wait_time_threshold` is reached a bad CN0 must not accumulate any
+    # out-of-lock time (the detector is still warming up).
+    detector = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30u"dBHz",
+        wait_time_threshold = 80u"ms",
+    )
+    detector = GNSSReceiver.update(detector, 5u"dBHz", 4u"ms")
+    @test detector.out_of_lock_time == 0u"s"
+    @test GNSSReceiver.is_in_lock(detector)
+end
+
+@testset "CarrierLockDetector accumulates out-of-lock on weak in-phase power" begin
+    detector = GNSSReceiver.CarrierLockDetector(;
+        out_of_lock_time_threshold = 200u"ms",
+        wait_time_threshold = 80u"ms",
+        integration_time_threshold = 80u"ms",
+    )
+    # A prompt dominated by its quadrature component fails the in-phase dominance
+    # test each integration block, so out-of-lock time accumulates and lock is lost.
+    weak_inphase = complex(0.1, 10.0)
+    for _ = 1:80
+        detector = GNSSReceiver.update(detector, weak_inphase, 4u"ms")
+    end
+    @test detector.out_of_lock_time > 0u"s"
+    @test !GNSSReceiver.is_in_lock(detector)
+
+    # A prompt dominated by its in-phase component resets the accumulated time.
+    strong_inphase = complex(10.0, 0.1)
+    for _ = 1:40
+        detector = GNSSReceiver.update(detector, strong_inphase, 4u"ms")
+    end
+    @test detector.out_of_lock_time == 0u"s"
+    @test GNSSReceiver.is_in_lock(detector)
+end

--- a/test/process.jl
+++ b/test/process.jl
@@ -57,3 +57,161 @@
 
     @test length(get_sat_states(next_receiver_state.track_state)) == 1
 end
+
+# Helpers for the reacquisition-path tests below. A satellite is "out of lock" once
+# its code lock detector has accumulated out-of-lock time past its threshold; we build
+# that state directly instead of driving many `update` calls through `process`.
+out_of_lock_code_detector() =
+    GNSSReceiver.CodeLockDetector(30.0u"dBHz", 250u"ms", 200u"ms", 80u"ms", 80u"ms")
+
+function out_of_lock_sat_state(system, prn)
+    GNSSReceiver.ReceiverSatState(
+        prn,
+        GNSSDecoderState(system, prn),
+        out_of_lock_code_detector(),
+        GNSSReceiver.CarrierLockDetector(),
+        0.0u"s",
+        0.0u"s",
+        0,
+        100.0u"Hz",
+    )
+end
+
+@testset "ReceiverSatState lock-timer transitions" begin
+    system = GPSL1CA()
+    # A satellite that has been in lock for a while (non-zero time_in_lock).
+    state = GNSSReceiver.ReceiverSatState(
+        1,
+        GNSSDecoderState(system, 1),
+        GNSSReceiver.CodeLockDetector(),
+        GNSSReceiver.CarrierLockDetector(),
+        5.0u"s",
+        0.0u"s",
+        0,
+        0.0u"Hz",
+    )
+
+    lost = GNSSReceiver.increase_time_out_of_lock(state, 4u"ms")
+    @test lost.time_in_lock == 0.0u"s"
+    @test lost.time_out_of_lock == 4u"ms"
+    @test lost.num_unsuccessful_reacquisition == 0
+
+    lost_again = GNSSReceiver.increase_time_out_of_lock(lost, 4u"ms")
+    @test lost_again.time_out_of_lock == 8u"ms"
+
+    reattempted = GNSSReceiver.increment_num_unsuccessful_reacquisition(lost)
+    @test reattempted.num_unsuccessful_reacquisition == 1
+    @test GNSSReceiver.increment_num_unsuccessful_reacquisition(
+        reattempted,
+    ).num_unsuccessful_reacquisition == 2
+end
+
+@testset "filter_in_lock_sats drops out-of-lock tracked satellites" begin
+    system = GPSL1CA()
+    track_state =
+        TrackState(system, [TrackedSat(system, 5, 0.0, 20u"Hz"; num_ants = NumAnts(1))])
+    receiver_sat_states = Dictionary([5], [out_of_lock_sat_state(system, 5)])
+
+    filtered = GNSSReceiver.filter_in_lock_sats(receiver_sat_states, track_state)
+    @test length(get_sat_states(filtered)) == 0
+end
+
+@testset "update_receiver_sat_states advances out-of-lock timer" begin
+    system = GPSL1CA()
+    track_state =
+        TrackState(system, [TrackedSat(system, 5, 0.0, 20u"Hz"; num_ants = NumAnts(1))])
+    receiver_sat_states = Dictionary([5], [out_of_lock_sat_state(system, 5)])
+
+    updated =
+        GNSSReceiver.update_receiver_sat_states(receiver_sat_states, track_state, 4u"ms")
+    @test updated[5].time_out_of_lock == 4u"ms"
+    @test !GNSSReceiver.is_in_lock(updated[5])
+end
+
+@testset "create_sat_state_from_acq builds a matching tracked-sat slot" begin
+    system = GPSL1CA()
+    num_ants = NumAnts(1)
+    empty_track_state =
+        ReceiverState(
+            ComplexF64,
+            system;
+            num_samples_for_acquisition = 20000,
+            num_ants,
+        ).track_state
+    acq = Acquisition.AcquisitionResults(
+        system,
+        5,
+        5e6u"Hz",
+        100.0u"Hz",
+        10.0,
+        nothing,
+        45.0,
+        1.0,
+        20.0,
+        1,
+        nothing,
+        (-5000.0:1000.0:5000.0)u"Hz",
+        1,
+        5000,
+        1,
+    )
+    tracked_sat = GNSSReceiver.create_sat_state_from_acq(acq, empty_track_state, num_ants)
+    # Built with the same slot type the track state uses, so `merge_sats` accepts it.
+    @test tracked_sat isa eltype(get_sat_states(empty_track_state))
+end
+
+@testset "update_states_from_acquisition_results is a no-op without detections" begin
+    system = GPSL1CA()
+    num_ants = NumAnts(1)
+    base = ReceiverState(ComplexF64, system; num_samples_for_acquisition = 20000, num_ants)
+    empty_track_state = base.track_state
+    empty_receiver_sat_states = base.receiver_sat_states[1]
+
+    # No acquisition results leaves both the track state and the receiver-sat-state
+    # dictionary untouched. (The detection-handover path is covered end-to-end by the
+    # reacquisition integration test, which feeds it real acquisition results.)
+    @test GNSSReceiver.update_states_from_acquisition_results(
+        Acquisition.AcquisitionResults[],
+        1e-4,
+        30.0u"dBHz",
+        empty_track_state,
+        empty_receiver_sat_states,
+        num_ants,
+    ) === (empty_track_state, empty_receiver_sat_states)
+end
+
+@testset "try_to_reacquire_lost_satellites counts failed reacquisitions" begin
+    system = GPSL1CA()
+    num_ants = NumAnts(1)
+    sampling_freq = 5e6Hz
+    acq_plan = plan_acquire(system, float(sampling_freq), collect(1:32))
+
+    # Fill the acquisition buffer with noise so `should_reacquire` fires but the
+    # (deterministic) acquisition finds nothing, driving the failed-reacquisition
+    # counter path.
+    rng = Random.Xoshiro(1)
+    noise = randn(rng, ComplexF64, 20000) * 512
+    acquisition_buffer = GNSSReceiver.SampleBuffers.buffer(
+        GNSSReceiver.SampleBuffer(ComplexF64, 20000),
+        noise,
+    )
+    @test GNSSReceiver.SampleBuffers.isfull(acquisition_buffer)
+
+    track_state =
+        TrackState(system, [TrackedSat(system, 5, 0.0, 20u"Hz"; num_ants = NumAnts(1))])
+    receiver_sat_states = Dictionary([5], [out_of_lock_sat_state(system, 5)])
+    @test GNSSReceiver.should_reacquire(receiver_sat_states[5])
+
+    _, updated_receiver_sat_states = GNSSReceiver.try_to_reacquire_lost_satellites(
+        acq_plan,
+        track_state,
+        receiver_sat_states,
+        acquisition_buffer,
+        0.0u"Hz",
+        1e-4,
+        30.0u"dBHz",
+        num_ants,
+        20000,
+    )
+    @test updated_receiver_sat_states[5].num_unsuccessful_reacquisition == 1
+end

--- a/test/receive.jl
+++ b/test/receive.jl
@@ -123,3 +123,34 @@ end
     @test all(d -> d.num_sats == 0, data)                # pure noise ⇒ nothing tracked
     @test issorted([d.runtime for d in data])            # runtime advances monotonically
 end
+
+@testset "Receive falls back to a runtime call for a non-inferrable extract" begin
+    sampling_freq = 5e6Hz
+    system = GPSL1CA()
+    num_samples = 20000
+    num_ants = 4
+    max_meas = 2^12
+
+    measurement_channel = make_noise_channel(Complex{Int16}, num_samples, num_ants)
+
+    # An extract whose return type inference can't pin down concretely (the
+    # inference barrier hides it as `Any`), even though every call returns an `Int`.
+    # `Base.promote_op` yields a non-concrete type, so `receive` falls back to
+    # calling `extract` on the initial state to learn the concrete payload type.
+    opaque_extract(rs) = Base.inferencebarrier(rs.num_samples_processed)::Any
+
+    data_channel = receive(
+        measurement_channel,
+        system,
+        sampling_freq;
+        num_ants = NumAnts(num_ants),
+        max_meas,
+        extract = opaque_extract,
+    )
+
+    # The fallback pins the concrete element type from the initial state's payload.
+    @test eltype(data_channel) == Int
+    data = collect_data(data_channel)
+    @test !isempty(data)
+    @test eltype(data) == Int
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ using Unitful: Hz, dBHz, ms
 include("aqua.jl")
 include("read_file.jl")
 include("beamformer.jl")
+include("lock_detector.jl")
 include("process.jl")
 include("gui.jl")
 include("save_data.jl")

--- a/test/sample_buffer.jl
+++ b/test/sample_buffer.jl
@@ -214,6 +214,29 @@ using GNSSReceiver.SampleBuffers
         @test SampleBuffers.isfull(buf_counter)
     end
 
+    @testset "Non-evicting append wraps around the end of the store" begin
+        # Construct a partially-filled buffer whose live window already starts partway
+        # into the backing store, so appending samples that still fit (no eviction)
+        # wraps past the physical end of the store.
+        base = SampleBuffer(Float64, 5, Val(2))
+        buf = SampleBuffers.SampleBuffer{Float64,Matrix{Float64}}(
+            base.buffer,
+            base.fifo_buffer,
+            5,   # max_length
+            1,   # current_length
+            3,   # start_index -> end_index = 3
+            1,   # first_sample_counter
+        )
+        buf.buffer[3, :] = [99.0, 98.0]
+
+        # 3 new samples: end_index (3) + 3 > max_length (5), so the write wraps.
+        new_samples = [1.0 2.0; 3.0 4.0; 5.0 6.0]
+        buf = buffer(buf, new_samples)
+        @test buf.current_length == 4
+        @test !SampleBuffers.isfull(buf)
+        @test get_samples(buf) == [99.0 98.0; 1.0 2.0; 3.0 4.0; 5.0 6.0]
+    end
+
     @testset "Helper functions for first sample counter" begin
         buf = SampleBuffer(Float64, 10, Val(2))
 


### PR DESCRIPTION
Closes the remaining code-coverage gaps in `src/` — all source files now report zero uncovered lines locally.

## What was uncovered and how it's covered now

| Source gap | Test |
|---|---|
| `lock_detector.jl` — accumulate/pay-back out-of-lock time | new **`test/lock_detector.jl`** drives both detectors through the out-of-lock transitions |
| `process.jl` reacquisition path (`filter_in_lock_sats` removal, `increase_time_out_of_lock`, `try_to_reacquire_lost_satellites`, `create_sat_state_from_acq`, detection handover) | new **mid-stream sample-slip test** in the ION integration test forces loss of lock on the real recording and reacquires end-to-end |
| failed-reacquisition counter (`increment_num_unsuccessful_reacquisition`) | focused unit test on a noise buffer (the always-succeeding real path never hits it) |
| `gui.jl` — "Decoding satellites" branch (≥4 sats, no PVT yet) | `test/gui.jl` |
| `receive.jl` — runtime fallback for a non-inferrable `extract` payload | `test/receive.jl` |
| `sample_buffer.jl` — non-evicting wrap-around append | `test/sample_buffer.jl` |

## Note on the sample slip

A single dropped sample is only a ~0.5-chip code-phase step, which the DLL absorbs (no loss of lock), and a full 2048-sample code period realigns exactly. A ~1.5-chip **3-sample** slip reliably pushes the peak out of the correlator window, so satellites drop and reacquire. The test slips at ~6 s and stops at ~8.8 s — before the 10 s periodic acquisition — so recovery is via reacquisition only. Deterministic across runs (11 locked → 5 → 7).

All changes are test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)