### PR TITLE
ci: add semantic-release workflow for automatic releases

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,41 @@
+---
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v6
+        id: semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          RUNNER_DEBUG: 1
+        with:
+          branches: |
+            ['+([0-9])?(.{+([0-9]),x}).x', 'master', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]
+          extends: |
+            @ethima/semantic-release-configuration
+          extra_plugins: |
+            @ethima/semantic-release-configuration
+      - name: Notify JuliaRegistrator of new release
+        uses: peter-evans/commit-comment@v4
+        if: steps.semantic-release.outputs.new_release_published == 'true'
+        with:
+          sha: ${{ steps.semantic-release.outputs.new_release_git_head }}
+          body: |
+            @JuliaRegistrator register
+
+            Release notes:
+
+            ${{ steps.semantic-release.outputs.new_release_notes }}


### PR DESCRIPTION
Copies the `Release.yml` workflow used by [JuliaGNSS/Tracking.jl](https://github.com/JuliaGNSS/Tracking.jl) and [JuliaGNSS/GNSSSignals.jl](https://github.com/JuliaGNSS/GNSSSignals.jl) (the two files are identical) so releases become automatic, matching the sibling packages.

Only change vs. the source: the push trigger is retargeted from `master` to this repo's `main` default branch (the internal semantic-release `branches` list already covers both).

## How it works

On every push to `main`, [semantic-release](https://github.com/cycjimmy/semantic-release-action):

1. Reads the **conventional-commit** messages since the last release (`feat:` → minor, `fix:` → patch, `BREAKING CHANGE`/`!` → major).
2. Bumps `Project.toml`, commits it back, and creates the GitHub release + tag with generated notes.
3. Comments `@JuliaRegistrator register` (with those notes) on the release commit → publishes to the General registry. TagBot then finalizes the tag.

This repo already uses conventional commits, so no history changes are needed.

## Prerequisites (please confirm)

- **`secrets.PAT`** — a Personal Access Token with `repo` scope must exist in this repo (or org). A plain `GITHUB_TOKEN` is deliberately not used: it can't push protected branches or trigger the downstream registrator. Tracking.jl / GNSSSignals.jl rely on the same `PAT` secret, so the org likely already provides it.
- The shared **`@ethima/semantic-release-configuration`** npm config (referenced verbatim from the sibling repos) defines the release rules incl. the Project.toml bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)