### PR TITLE
build(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# [2.1.0](https://github.com/JuliaGNSS/GNSSReceiver.jl/compare/v2.0.0...v2.1.0) (2026-07-26)
+
+
+### Features
+
+* support Tracking 4 ([76338f7](https://github.com/JuliaGNSS/GNSSReceiver.jl/commit/76338f7))
+
 # [2.0.0](https://github.com/JuliaGNSS/GNSSReceiver.jl/compare/v1.0.0...v2.0.0) (2026-07-19)
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GNSSReceiver"
 uuid = "c84cffac-6943-4fe6-9449-f6d23817af8b"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Soeren Schoenbrod <soeren.schoenbrod@outlook.de> and contributors"]
 
 [deps]


### PR DESCRIPTION
Manual release commit for the Tracking 4 support merged in #111.

`semantic-release` does not bump on `build(deps):` commits (like #111's `build(deps): allow Tracking 4`), so the version bump is made by hand, mirroring [PositionVelocityTime.jl#56](https://github.com/JuliaGNSS/PositionVelocityTime.jl/pull/56).

## Changes
- `Project.toml`: `version = "2.0.0"` → `"2.1.0"` (minor — adding Tracking 4 support is a backwards-compatible addition)
- `CHANGELOG.md`: add the 2.1.0 entry

## After merge
Registration is handled separately by the maintainer (tag `v2.1.0` + `@JuliaRegistrator register`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)