### PR TITLE
test: retry Aqua's persistent-tasks wrapper precompile

### DIFF
--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,10 +1,28 @@
 using Aqua
 
 @testset "Aqua quality assurance" begin
-    # `persistent_tasks` with a longer `tmax`: no dependency actually spawns a persistent
-    # task (`Aqua.find_persistent_tasks_deps(GNSSReceiver)` is empty), and the receiver only
-    # spawns tasks at runtime inside `gui`/`receive`, never at load. But loading the heavier
-    # UI dependency graph (Tachikoma, UnicodePlots, …) can take longer than Aqua's default
-    # 10 s settling window on slow CI (Windows), tripping a false positive — so give it more.
-    Aqua.test_all(GNSSReceiver; ambiguities = false, persistent_tasks = (tmax = 60,))
+    # `persistent_tasks` runs separately below, with a retry.
+    Aqua.test_all(GNSSReceiver; ambiguities = false, persistent_tasks = false)
+
+    # Aqua looks for load-time tasks by precompiling a throwaway package that `using`s
+    # GNSSReceiver and then, from inside the precompile process, writes a `done.log`
+    # sentinel; a package whose tasks keep that process alive past `tmax` is flagged. The
+    # receiver only spawns tasks at runtime inside `gui`/`receive`, never at load, but that
+    # wrapper resolves a manifest of its own, so the whole graph (Tachikoma, UnicodePlots,
+    # SoapySDR, …) precompiles cold and in parallel — where a module can lose the Julia 1.12
+    # cache race ("… is missing from the cache", "may be precompilable after restarting
+    # julia"). `Pkg` then exits *without* compiling the wrapper, the sentinel never appears,
+    # and Aqua misreports a persistent task (JuliaTesting/Aqua.jl#315): that is how the
+    # 3.1.0 Windows job failed on a tree whose Windows job had passed minutes earlier.
+    # A larger `tmax` cannot help — it only bounds the wait *after* the sentinel appears —
+    # so retry, which the asserting `test_persistent_tasks` cannot do; the second attempt
+    # finds the graph precompiled and gets there quickly. A genuine persistent task writes
+    # the sentinel and *then* holds the process open, so it is still caught on every
+    # attempt.
+    @testset "Persistent tasks" begin
+        package = Base.PkgId(GNSSReceiver)
+        # `tmax` beyond Aqua's 10 s default: on a slow Windows runner, wrapping up the
+        # wrapper's precompilation after the sentinel appears can take longer than that.
+        @test any(_ -> !Aqua.has_persistent_tasks(package; tmax = 60), 1:3)
+    end
 end


### PR DESCRIPTION
## The failure

The Windows job of the 3.1.0 Test run failed in Aqua:

```
┌ Error: Unexpected error: C:\Users\RUNNER~1\AppData\Local\Temp\jl_81m7Kby38h\done.log was not created, but precompilation exited
└ @ Aqua …\Aqua\h1qD0\src\persistent_tasks.jl:120
Persistent tasks: Test Failed
  Expression: !(has_persistent_tasks(package; kwargs...))
```

([run 30263198703](https://github.com/JuliaGNSS/GNSSReceiver.jl/actions/runs/30263198703), and the same on the `v3.1.0` tag run.) `075700b` only bumps the version, and its parent's Windows job had passed 27 s earlier; re-running the failed job unchanged made it **pass**, so this is not a regression.

## Root cause

`Aqua.test_persistent_tasks` precompiles a throwaway wrapper package that `using`s GNSSReceiver and then, from inside the precompile process, writes a `done.log` sentinel — a package whose tasks keep that process alive past `tmax` is flagged. The wrapper resolves a manifest of its own, so this package's whole graph (Tachikoma, UnicodePlots, SoapySDR, …) precompiles cold and in parallel, and there a module can lose Julia 1.12's cache race (`… is missing from the cache` / `may be precompilable after restarting julia`). `Pkg.precompile` then exits *without ever compiling the wrapper*, so the sentinel never appears and Aqua reports a persistent task — the misclassification tracked in [JuliaTesting/Aqua.jl#315](https://github.com/JuliaTesting/Aqua.jl/issues/315), reproduced in detail in [SciML/SciMLSensitivity.jl#1554](https://github.com/SciML/SciMLSensitivity.jl/issues/1554) and seen intermittently on 1.12 runners in [BiochemicalAlgorithms.jl#217](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/issues/217).

The receiver itself spawns tasks only at runtime inside `gui`/`receive`, never at load. The `tmax = 60` bump from eb2d77f cannot address this failure mode: `tmax` only bounds the wait *after* the sentinel appears, and here the process exits before writing it.

## The fix

Take `persistent_tasks` out of `test_all` and drive it from `Aqua.has_persistent_tasks` with up to three attempts — retrying is exactly what the asserting `test_persistent_tasks` cannot do. The retry only fires on the missing-sentinel path, and the second attempt finds the graph already precompiled in the depot, so it gets there quickly.

Nothing is skipped, `@test_broken`ed or loosened. A genuine load-time task writes the sentinel and *then* holds the process open, so it is still caught on every attempt.

## Verification (local, Julia 1.12.1, Aqua 0.8.16 — the version CI resolved)

- `test/aqua.jl` passes: `Aqua quality assurance | 10 pass`, same count as before.
- Detection is intact: injecting a real persistent task through Aqua's `expr` hook (`Threads.@spawn while true; sleep(1); end`) still fails the check on all three attempts.
- `JuliaFormatter` reports the file as already formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)