### PR TITLE
ci: skip the release workflow on its own release commit

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   release:
     name: Release
+    # semantic-release pushes its own version bump to main, which triggers
+    # this workflow again. That re-run races the tag push: when it loses, it
+    # does not see the tag it just released, recomputes the same version and
+    # fails because the version in Project.toml is already the one it wants
+    # to write. The message prefix comes from the release configuration.
+    if: "!startsWith(github.event.head_commit.message, 'build(release):')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Ports the guard from [RINEXParser.jl#5](https://github.com/JuliaGNSS/RINEXParser.jl/pull/5), which runs this workflow verbatim and hit the failure it prevents.

## The failure mode

semantic-release pushes its own `build(release): X.Y.Z` commit to `main`, so the workflow triggers again — and that re-run races the tag push. Which way the race falls decides the outcome:

- **Race won** (every release here so far): the re-run sees the new tag, finds `0 commits since last release` and exits with *"There are no relevant changes, so no new version is released."* — e.g. [`build(release): 3.1.0`](https://github.com/JuliaGNSS/GNSSReceiver.jl/actions/runs/30263198744), green in 25 s.
- **Race lost** (RINEXParser.jl v0.2.0, [run 30794422967](https://github.com/JuliaGNSS/RINEXParser.jl/actions/runs/30794422967)): the tag was pushed 3 s after the re-run had already read the tags, so it reported `Found git tag v0.1.0`, recomputed `The next release version is 0.2.0` and failed in `prepare`:

  ```
  Error: Expected match not found!
    "file": "Project.toml",
  - "hasChanged": false,     "numMatches": 1,
  - "numReplacements": 0,
  ```

  Writing `version = "0.2.0"` into a `Project.toml` that already said so changes nothing, while `@ethima/semantic-release-configuration` asserts the bump changed exactly one line (`hasChanged: true, numMatches: 1, numReplacements: 1`).

The release itself is unaffected — tag, GitHub release and the Registrator comment all come from the first run — but `main` keeps a failed run per release, and it is luck that this repo has not seen one yet.

## The fix

The re-run has nothing to release either way, so the job is skipped for that commit. The `build(release):` prefix is fixed by the git plugin's message template in the shared release configuration, and the quoting on the `if:` is required — a bare `!` would be read as a YAML tag.

Raising `fetch-depth` on the checkout does *not* close this: the tag genuinely was not on the remote yet, so no fetch setting would have found it.

## Validation

Verified on RINEXParser.jl, where the same guard shipped one commit before its next release:

```
skipped   build(release): 0.2.1   Release   1s     ← with the guard
failure   build(release): 0.2.0   Release   24s    ← without
```

The YAML parses and the expression survives the quoting. It cannot be exercised from a PR, since `Release` only triggers on pushes to `main` — the first release after merging is the live test, and the expected signal is a *skipped* `Release` run on the `build(release):` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
