### PR TITLE
feat: stage the lock detectors through the acquisition handover and scale their timings to the code period

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -51,9 +51,12 @@ SatelliteDataOfInterest
 
 ```@docs
 AbstractLockDetector
+LockDwell
 CodeLockDetector
 CarrierLockDetector
 is_in_lock
+has_pulled_in
+is_ranging_ready
 phase_lock_indicator
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,6 +54,7 @@ AbstractLockDetector
 CodeLockDetector
 CarrierLockDetector
 is_in_lock
+phase_lock_indicator
 ```
 
 ## Beamforming

--- a/docs/src/custom_output.md
+++ b/docs/src/custom_output.md
@@ -36,7 +36,7 @@ read are:
 | Field | What it holds | Useful accessors |
 |---|---|---|
 | `track_state` | Tracking's per-satellite loop state, grouped by signal | `get_sat_states(track_state, group_key)`, then per `sat_state`: `get_prn`, `get_carrier_doppler`, `get_code_phase`, `get_carrier_phase`, `estimate_cn0` (from [Tracking](https://github.com/JuliaGNSS/Tracking.jl)) |
-| `receiver_sat_states` | A `NamedTuple` keyed by signal id (`:GPSL1CA`, …); each value is a `Dictionaries.Dictionary{Int,ReceiverSatState}` keyed by PRN | `GNSSReceiver.is_sat_healthy(…​.decoder)`, plus the decoded ephemeris in `…​.decoder` (from [GNSSDecoder](https://github.com/JuliaGNSS/GNSSDecoder.jl)) |
+| `receiver_sat_states` | A `NamedTuple` keyed by signal id (`:GPSL1CA`, …); each value is a `Dictionaries.Dictionary{Int,ReceiverSatState}` keyed by PRN | `GNSSReceiver.is_sat_healthy(…​.decoder)`, plus the decoded ephemeris in `…​.decoder` (from [GNSSDecoder](https://github.com/JuliaGNSS/GNSSDecoder.jl)); `GNSSReceiver.is_in_lock(…)` and `GNSSReceiver.is_ranging_ready(…)` for the lock stage (see [Acquisition & Tracking Parameters](@ref)) |
 | `pvt` | Current PVT solution | fields of `PositionVelocityTime.PVTSolution` |
 | `runtime` | Elapsed signal time | — |
 

--- a/docs/src/gui.md
+++ b/docs/src/gui.md
@@ -5,11 +5,13 @@ GNSSReceiver.jl ships a live, interactive **terminal dashboard** (built on
 processes samples. It lays out four panels:
 
 - **Carrier-to-Noise-Density Ratio (CN0)** — a bar per tracked satellite (labelled with
-  the RINEX-style satellite id and band, e.g. `G05 L1`). Every satellite shown is in lock,
-  and the colour says whether it is contributing to the fix: **green** when it is healthy
-  and its tracking loops have settled enough to range on, **yellow** when it is healthy but
-  still settling — normal for roughly the first second after acquisition, see the lock
-  detection section of [Acquisition & Tracking Parameters](@ref) — and **red** when the
+  the RINEX-style satellite id and band, e.g. `G05 L1`). The colour says whether the
+  satellite is contributing to the fix: **green** when it is healthy, in lock and its
+  tracking loops have settled enough to range on, **yellow** when it is healthy but the
+  receiver is not ranging on it — either still settling, normal for roughly the first second
+  after acquisition (see the lock detection section of
+  [Acquisition & Tracking Parameters](@ref)), or a vector-loop member that has lost lock and
+  is being carried through an outage by the navigation filter — and **red** when the
   satellite declares itself unhealthy in its navigation message.
 - **Satellite Direction-of-Arrival** — a sky plot of the satellites in view, each drawn at
   its azimuth/elevation and labelled with its PRN, coloured by constellation (green GPS,

--- a/docs/src/gui.md
+++ b/docs/src/gui.md
@@ -5,8 +5,12 @@ GNSSReceiver.jl ships a live, interactive **terminal dashboard** (built on
 processes samples. It lays out four panels:
 
 - **Carrier-to-Noise-Density Ratio (CN0)** — a bar per tracked satellite (labelled with
-  the RINEX-style satellite id and band, e.g. `G05 L1`), coloured green when the satellite
-  is healthy and red otherwise.
+  the RINEX-style satellite id and band, e.g. `G05 L1`). Every satellite shown is in lock,
+  and the colour says whether it is contributing to the fix: **green** when it is healthy
+  and its tracking loops have settled enough to range on, **yellow** when it is healthy but
+  still settling — normal for roughly the first second after acquisition, see the lock
+  detection section of [Acquisition & Tracking Parameters](@ref) — and **red** when the
+  satellite declares itself unhealthy in its navigation message.
 - **Satellite Direction-of-Arrival** — a sky plot of the satellites in view, each drawn at
   its azimuth/elevation and labelled with its PRN, coloured by constellation (green GPS,
   blue Galileo, red GLONASS, yellow BeiDou), with a legend below. Azimuth runs clockwise

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -181,10 +181,12 @@ at the 30 dB-Hz threshold itself, 0.10 one dB above it and 0.00 from two dB up),
 carrier detector does: its phase-lock indicator takes 460 to 590 code periods to come up
 through the handover. And against any disturbance recurring on a period shorter than the run
 the evidence path never fires at all, at any C/N0. The backstop admits such a satellite once
-enough signal has *elapsed* — two code-loop time constants — with its out-of-lock clock still
-inside what steady state tolerates. What it concedes is a few metres of extra code-phase
-thermal jitter (1σ of 0.039 chip, 11 m, at 30 dB-Hz against 0.004 chip, 1.2 m, at 45), not a
-converging handover bias.
+enough signal has *elapsed* — two code-loop time constants — with its out-of-lock clock paid
+down to zero. What it shortens is the *length* of the clean run it asks for, not the
+requirement that the channel be clean: a channel failing steadily enough never to pay its debt
+off is dropped by the dwell rather than admitted here. What it concedes is a few metres of
+extra code-phase thermal jitter (1σ of 0.039 chip, 11 m, at 30 dB-Hz against 0.004 chip,
+1.2 m, at 45), not a converging handover bias.
 
 One residual case is left open deliberately: a satellite whose accumulated out-of-lock time
 parks *between* the steady-state and pull-in allowances — 200 to 600 code periods — never

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -101,15 +101,19 @@ float backend with no full-scale value. See [Getting Started](@ref).
 ## Lock detection
 
 A satellite contributes to the PVT solution only while it is *in lock*. Lock is declared
-per satellite by a [`CodeLockDetector`](@ref GNSSReceiver.CodeLockDetector) **and** a
-[`CarrierLockDetector`](@ref GNSSReceiver.CarrierLockDetector). Both track elapsed signal
-time, so their behaviour is independent of how the signal is chunked, and both take their
-timings as counts of the ranging signal's primary code period rather than in seconds, so
-they mean the same thing on every signal (see [Timings scale with the code period](@ref)).
+per satellite by a [`CodeLockDetector`](@ref GNSSReceiver.CodeLockDetector) — a threshold on
+the post-integration SNR — **and** a
+[`CarrierLockDetector`](@ref GNSSReceiver.CarrierLockDetector) — the narrowband
+difference/power phase-lock indicator `Σ(I²−Q²)/Σ(I²+Q²)`, fed every prompt the tracking
+loops produce. Both track elapsed signal time, so their behaviour is independent of how the
+signal is chunked, and both take their timings as counts of the ranging signal's primary
+code period rather than in seconds, so they mean the same thing on every signal (see
+[Timings scale with the code period](@ref)).
 
-The detector thresholds and timings (the code-lock CN0 threshold, out-of-lock, warm-up and
-carrier integration windows) are set at detector construction from per-signal defaults; see
-their docstrings in the [API Reference](@ref).
+The detector thresholds and timings (the code-lock CN0 threshold, the carrier phase-lock
+threshold and its smoothing window, and the out-of-lock and warm-up windows) are set at
+detector construction from per-signal defaults; see their docstrings in the
+[API Reference](@ref).
 
 The CN0 threshold is referred to a record spanning **one primary code period**, because what
 decides detectability is the post-integration SNR `CN0 · T` rather than CN0 on its own.
@@ -159,8 +163,7 @@ it is correct — but only 50 on Galileo E1B and 20 on GPS L1C-D, against loops 
 and ten times slower. That is why lock detection failed on the slower signals while GPS
 L1 C/A looked fine. The GPS L1 C/A numbers are unchanged.
 
-The counts themselves (out-of-lock, warm-up and carrier integration windows) are set at
-detector construction; see the
+The counts themselves are set at detector construction; see the
 [`CodeLockDetector`](@ref GNSSReceiver.CodeLockDetector) and
 [`CarrierLockDetector`](@ref GNSSReceiver.CarrierLockDetector) docstrings in the
 [API Reference](@ref) for the defaults.

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -143,6 +143,58 @@ signal. The threshold is not a `receive` keyword: it comes from the per-signal d
 `CodeLockDetector` is constructed with, which is where sensitivity would have to be traded.
 The estimate is also what `sat_data[…].cn0` reports and what the GUI plots.
 
+### Two stages: handover, then steady state
+
+The acquisition → tracking handover is deliberately coarse — the acquisition Doppler bin is
+half the tracking loop's pull-in range, and the code phase is only resolved to the sample
+grid, halved by `subsample_interpolation`. Until the loops have pulled those errors in, the
+prompt correlator sits off the correlation peak and reports *less* power than the satellite
+really has, and the carrier phase is still spinning at the residual Doppler, so a perfectly
+healthy satellite looks weak to both detectors.
+
+Both detectors therefore run a **pull-in stage** with a generous out-of-lock allowance,
+latching permanently into a tighter **steady state** once the satellite has either strung
+together enough good evidence to count as converged or exhausted its pull-in window. This buys
+handover tolerance without making a genuine signal loss slower to notice. Measured on
+synthetic handovers at this receiver's own worst-case residual, the peak accumulated
+out-of-lock time a satellite the receiver should keep demands is 292 code periods — more than
+the 200-code-period steady-state dwell tolerates, which is why a single un-staged dwell drops
+it.
+
+Ranging is gated separately from tracking, and on a *later* criterion. A satellite in its
+pull-in stage is still *kept* — that is the point — but it does not contribute to the PVT
+solution until its loops have settled, because a code phase that is still converging produces
+a pseudorange biased by tens of metres: measured at a 0.25-chip handover, the residual is 0.15
+to 0.22 chip (44 to 64 m) after 200 code periods of clean evidence and 0.018 to 0.15 chip (5
+to 44 m) after 600. `time_in_lock_before_calculating_pvt` alone would not achieve this: it
+counts from the handover, so it can elapse while the loops are still settling — and on a code
+longer than 1 ms the settling takes proportionally longer while that gate stays fixed in
+seconds.
+
+Ranging readiness needs a **timer** as well as an evidence path, for the same reason the
+pull-in stage does: the evidence clock is reset by any out-of-lock verdict, so an uninterrupted
+run is a bar a satellite can fail to clear indefinitely — and it would then be tracked,
+converged, and silently absent from the PVT solve forever. Since PVT needs four satellites,
+that trades a degraded fix for no fix. Under Tracking's default noise-reference estimator the
+code detector rarely blocks the run (measured steady-state per-chunk out-of-lock rates are 0.58
+at the 30 dB-Hz threshold itself, 0.10 one dB above it and 0.00 from two dB up), but the
+carrier detector does: its phase-lock indicator takes 460 to 590 code periods to come up
+through the handover. And against any disturbance recurring on a period shorter than the run
+the evidence path never fires at all, at any C/N0. The backstop admits such a satellite once
+enough signal has *elapsed* — two code-loop time constants — with its out-of-lock clock still
+inside what steady state tolerates. What it concedes is a few metres of extra code-phase
+thermal jitter (1σ of 0.039 chip, 11 m, at 30 dB-Hz against 0.004 chip, 1.2 m, at 45), not a
+converging handover bias.
+
+One residual case is left open deliberately: a satellite whose accumulated out-of-lock time
+parks *between* the steady-state and pull-in allowances — 200 to 600 code periods — never
+leaves the pull-in stage, and so never becomes ranging-ready either. Reaching it takes a burst
+of failures followed by a sustained near-50% duty cycle; under a stochastic signal the clock
+random-walks out of that band, either down to zero (whereupon it latches) or up past the
+pull-in allowance (whereupon lock is lost and the satellite is reacquired). Closing it would
+mean letting the pull-in stage latch while its clock is still above the steady-state threshold,
+which is exactly the discontinuity the latch guard exists to prevent.
+
 ### Timings scale with the code period
 
 Every detector timing is configured as a multiple of the ranging signal's **primary code
@@ -151,17 +203,34 @@ scale with: Tracking sizes its default bandwidths at `B_L·T ≈ 0.018`, so a 1 
 18 Hz carrier / 1 Hz code loop while a 10 ms code gets 1.8 Hz / 0.1 Hz — every `1/B_L` is a
 fixed number of code periods.
 
-| Signal | Code period | Warm-up (80 `T`) | Code dwell (200 `T`) | Carrier dwell (4000 `T`) |
-|---|---|---|---|---|
-| GPS L1 C/A | 1 ms | 80 ms | 200 ms | 4 s |
-| Galileo E1B | 4 ms | 320 ms | 800 ms | 16 s |
-| GPS L1C-D | 10 ms | 800 ms | 2 s | 40 s |
+| Signal | Code period | Warm-up (80 `T`) | Code dwell (200 `T`) | Pull-in allowance (600 `T`) | Ranging ready (≥ 680 `T`) | Ranging backstop (2000 `T`) |
+|---|---|---|---|---|---|---|
+| GPS L1 C/A | 1 ms | 80 ms | 200 ms | 600 ms | ≥ 680 ms | 2 s |
+| Galileo E1B | 4 ms | 320 ms | 800 ms | 2.4 s | ≥ 2.7 s | 8 s |
+| GPS L1C-D | 10 ms | 800 ms | 2 s | 6 s | ≥ 6.8 s | 20 s |
+
+"Ranging ready" is the evidence path — the warm-up plus an uninterrupted 600-code-period run,
+so 680 `T` is a floor rather than a typical value: measured on real handovers it lands at 760
+to 1500 code periods on GPS L1 C/A, because the carrier loop has its own Doppler pull-in to do
+before the phase-lock indicator stops resetting the run. "Ranging backstop" is the timer that
+bounds the wait for a satellite whose evidence never comes cleanly. The carrier
+detector's own dwell is 4000 `T` (4 s on GPS L1 C/A) and, being floored at that, is unstaged:
+it clears outright on any favourable chunk, so declaring loss already needs a consecutive run
+of failures far longer than any handover transient.
 
 A dwell fixed in seconds means something different on every signal: the 200 ms this receiver
 used to allow is 200 code periods on GPS L1 C/A — the signal it was tuned against, and where
 it is correct — but only 50 on Galileo E1B and 20 on GPS L1C-D, against loops that are four
 and ten times slower. That is why lock detection failed on the slower signals while GPS
-L1 C/A looked fine. The GPS L1 C/A numbers are unchanged.
+L1 C/A looked fine. The GPS L1 C/A warm-up and dwell are unchanged.
+
+One consequence worth stating outright: on codes longer than 1 ms these timings, not
+`time_in_lock_before_calculating_pvt`, are what actually decide when a satellite joins the
+solve. A healthy GPS L1 C/A satellite is ranging-ready between 0.76 s and 1.5 s depending on
+its C/N0, so the 2 s default still binds there. On Galileo E1B (2.7 s at best) and GPS L1C-D
+(6.8 s) it no longer does, and lowering it below those figures has no effect at all. The extra
+seconds are in practice dwarfed by the tens of seconds of subframe decoding that set time to
+first fix.
 
 The counts themselves are set at detector construction; see the
 [`CodeLockDetector`](@ref GNSSReceiver.CodeLockDetector) and

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -103,7 +103,9 @@ float backend with no full-scale value. See [Getting Started](@ref).
 A satellite contributes to the PVT solution only while it is *in lock*. Lock is declared
 per satellite by a [`CodeLockDetector`](@ref GNSSReceiver.CodeLockDetector) **and** a
 [`CarrierLockDetector`](@ref GNSSReceiver.CarrierLockDetector). Both track elapsed signal
-time, so their behaviour is independent of how the signal is chunked.
+time, so their behaviour is independent of how the signal is chunked, and both take their
+timings as counts of the ranging signal's primary code period rather than in seconds, so
+they mean the same thing on every signal (see [Timings scale with the code period](@ref)).
 
 The detector thresholds and timings (the code-lock CN0 threshold, out-of-lock, warm-up and
 carrier integration windows) are set at detector construction from per-signal defaults; see
@@ -137,9 +139,31 @@ signal. The threshold is not a `receive` keyword: it comes from the per-signal d
 `CodeLockDetector` is constructed with, which is where sensitivity would have to be traded.
 The estimate is also what `sat_data[…].cn0` reports and what the GUI plots.
 
-The remaining detector timings (out-of-lock, warm-up and carrier integration windows) are
-set at detector construction; see their docstrings in the [API Reference](@ref) for the
-defaults.
+### Timings scale with the code period
+
+Every detector timing is configured as a multiple of the ranging signal's **primary code
+period** rather than in seconds, because that is what the tracking loops' time constants
+scale with: Tracking sizes its default bandwidths at `B_L·T ≈ 0.018`, so a 1 ms code gets an
+18 Hz carrier / 1 Hz code loop while a 10 ms code gets 1.8 Hz / 0.1 Hz — every `1/B_L` is a
+fixed number of code periods.
+
+| Signal | Code period | Warm-up (80 `T`) | Code dwell (200 `T`) | Carrier dwell (4000 `T`) |
+|---|---|---|---|---|
+| GPS L1 C/A | 1 ms | 80 ms | 200 ms | 4 s |
+| Galileo E1B | 4 ms | 320 ms | 800 ms | 16 s |
+| GPS L1C-D | 10 ms | 800 ms | 2 s | 40 s |
+
+A dwell fixed in seconds means something different on every signal: the 200 ms this receiver
+used to allow is 200 code periods on GPS L1 C/A — the signal it was tuned against, and where
+it is correct — but only 50 on Galileo E1B and 20 on GPS L1C-D, against loops that are four
+and ten times slower. That is why lock detection failed on the slower signals while GPS
+L1 C/A looked fine. The GPS L1 C/A numbers are unchanged.
+
+The counts themselves (out-of-lock, warm-up and carrier integration windows) are set at
+detector construction; see the
+[`CodeLockDetector`](@ref GNSSReceiver.CodeLockDetector) and
+[`CarrierLockDetector`](@ref GNSSReceiver.CarrierLockDetector) docstrings in the
+[API Reference](@ref) for the defaults.
 
 ## PVT
 

--- a/src/GNSSReceiver.jl
+++ b/src/GNSSReceiver.jl
@@ -233,7 +233,9 @@ function ReceiverSatState(
             cn0_threshold = code_lock_cn0_threshold,
             reference_integration_time = primary_code_period(acq.system),
         ),
-        CarrierLockDetector(),
+        CarrierLockDetector(;
+            reference_integration_time = primary_code_period(acq.system),
+        ),
         0.0s,
         0.0s,
         0,
@@ -254,7 +256,9 @@ function ReceiverSatState(
             # The detector runs on the ranging signal, so its code period is the reference.
             reference_integration_time = primary_code_period(ranging_signal(system)),
         ),
-        CarrierLockDetector(),
+        CarrierLockDetector(;
+            reference_integration_time = primary_code_period(ranging_signal(system)),
+        ),
         0.0s,
         0.0s,
         0,

--- a/src/GNSSReceiver.jl
+++ b/src/GNSSReceiver.jl
@@ -282,6 +282,25 @@ function is_in_lock(state::ReceiverSatState)
     end
 end
 
+# Whether the satellite's loops have settled enough to range on. `is_in_lock` decides whether
+# to keep *tracking* a satellite and is deliberately tolerant through the handover; this
+# decides whether its measurements are trustworthy. See
+# `is_ranging_ready(::AbstractLockDetector)`.
+function is_ranging_ready(state::ReceiverSatState)
+    if state.in_vt_loop
+        # Code detector only, mirroring `is_in_lock` above and for a sharper reason: a
+        # coasted vector-loop member's carrier phase-lock indicator is starved through the
+        # outage, so its carrier latch may never have fired. ANDing it unconditionally would
+        # permanently exclude a member that joined the loop before that happened — while the
+        # navigation filter was steering both its NCOs and keeping the code aligned, which is
+        # exactly the state in which its pseudorange *is* usable.
+        is_ranging_ready(state.code_lock_detector)
+    else
+        is_ranging_ready(state.code_lock_detector) &&
+            is_ranging_ready(state.carrier_lock_detector)
+    end
+end
+
 function increase_time_out_of_lock(state::ReceiverSatState, time::Unitful.Time)
     @reset state.time_in_lock = 0.0s
     @reset state.time_out_of_lock = state.time_out_of_lock + time

--- a/src/dashboard.jl
+++ b/src/dashboard.jl
@@ -283,17 +283,26 @@ function _cn0_db(cn0)
     isfinite(db) ? max(round(db; digits = 1), 0.0) : 0.0
 end
 
-# Bar colour for one satellite in the CN0 panel. Every satellite shown is in lock, so the
-# three colours separate the reasons it may still not be contributing to the fix:
+# Bar colour for one satellite in the CN0 panel. The three colours separate the reasons a
+# tracked satellite may not be contributing to the fix:
 #
 #   * red    — the satellite declares itself unhealthy in its navigation message. Worst news
 #              and unrelated to our own tracking, so it wins over the readiness stage.
-#   * yellow — healthy, but its loops have not settled enough to range on yet: the handover
-#              is deliberately tolerated, so this is normal for the first second or so after
-#              acquisition (see `is_ranging_ready`). Without this state such a satellite is
-#              indistinguishable from one the PVT solve ignores for no visible reason.
+#   * yellow — healthy, but the receiver is not ranging on it: either its loops have not
+#              settled enough yet (the handover is deliberately tolerated, so this is normal
+#              for the first second or so after acquisition — see `is_ranging_ready`), or it
+#              has lost lock and is only still on screen because the vector-tracking filter
+#              is carrying it through an outage. Both are what `collect_pvt_sat_states!`
+#              withholds from the solve, and without this state such a satellite would be
+#              indistinguishable from one the solve ignores for no visible reason.
 #   * green  — healthy and contributing.
-_sat_bar_color(sat) = !sat.is_healthy ? :red : sat.is_ranging_ready ? :green : :yellow
+#
+# Both conditions are needed. A scalar-tracked satellite is dropped from tracking the moment
+# it loses lock, so `is_in_lock` is constant-true for it — but a vector-loop member is not
+# dropped, and its `is_ranging_ready` stays latched from before the outage by design, so
+# readiness alone would paint a coasting member green.
+_sat_bar_color(sat) =
+    !sat.is_healthy ? :red : (sat.is_ranging_ready && sat.is_in_lock) ? :green : :yellow
 
 function _render_cn0(buf, area::Rect, gui_data, num_dots)
     # One marker column carries both memberships, which are different sets: the vector loop

--- a/src/dashboard.jl
+++ b/src/dashboard.jl
@@ -283,6 +283,18 @@ function _cn0_db(cn0)
     isfinite(db) ? max(round(db; digits = 1), 0.0) : 0.0
 end
 
+# Bar colour for one satellite in the CN0 panel. Every satellite shown is in lock, so the
+# three colours separate the reasons it may still not be contributing to the fix:
+#
+#   * red    — the satellite declares itself unhealthy in its navigation message. Worst news
+#              and unrelated to our own tracking, so it wins over the readiness stage.
+#   * yellow — healthy, but its loops have not settled enough to range on yet: the handover
+#              is deliberately tolerated, so this is normal for the first second or so after
+#              acquisition (see `is_ranging_ready`). Without this state such a satellite is
+#              indistinguishable from one the PVT solve ignores for no visible reason.
+#   * green  — healthy and contributing.
+_sat_bar_color(sat) = !sat.is_healthy ? :red : sat.is_ranging_ready ? :green : :yellow
+
 function _render_cn0(buf, area::Rect, gui_data, num_dots)
     # One marker column carries both memberships, which are different sets: the vector loop
     # (`in_vt_loop`) and the satellites whose measurements determined this fix (`pvt.sats`).
@@ -306,8 +318,8 @@ function _render_cn0(buf, area::Rect, gui_data, num_dots)
             tstyle(:text_dim); max_x = right(inner))
         return
     end
-    # Bars sorted by constellation (GPS, then Galileo, …), then PRN, then band; coloured
-    # green (healthy) / red (unhealthy). The mark goes right after the PRN (`G03* L1`), with a
+    # Bars sorted by constellation (GPS, then Galileo, …), then PRN, then band; coloured by
+    # `_sat_bar_color`. The mark goes right after the PRN (`G03* L1`), with a
     # blank in that column for an unmarked bar, so no space precedes it, all labels stay one
     # width, and `barplot`'s right-justification keeps the PRN/band columns aligned.
     # `sat_label` is `<sys><2-digit prn> <3-char band>`, so the mark goes at index 4. The column
@@ -343,7 +355,7 @@ function _render_cn0(buf, area::Rect, gui_data, num_dots)
         lbl[1:3] * mark * lbl[4:end]
     end
     cn0s = [_cn0_db(gui_data.sat_data[key].cn0) for key in shown_keys]
-    colors = [gui_data.sat_data[key].is_healthy ? :green : :red for key in shown_keys]
+    colors = [_sat_bar_color(gui_data.sat_data[key]) for key in shown_keys]
     labelw = maximum(length, labels)
     # Chrome `barplot` draws around the bars themselves: the label column, then `" ┤"`
     # between label and bar, then the value printed after the bar (" 45.1" — a space plus up

--- a/src/lock_detector.jl
+++ b/src/lock_detector.jl
@@ -137,11 +137,27 @@ run: measured steady-state per-chunk out-of-lock rates with no handover error ar
 code detector holds at all completes a clean run easily. The **carrier** detector is what
 blocks it: its 460-to-590-code-period pull-in transient resets `settled_time` well after the
 code detector is happy, and any recurring disturbance shorter than the run reopens the same
-hole at any C/N0. So `ranging_pull_in_time_threshold` (2000 code periods) backstops it, under
-the same guard as `pulled_in`'s timer — the out-of-lock clock must be within what steady state
-tolerates, so a channel that is genuinely failing is dropped by `is_in_lock` rather than
-admitted by the timer. It also takes `pulled_in` as a conjunct, so "ranging is never ready
-before the handover is over" holds structurally rather than by threshold ordering.
+hole at any C/N0. So `ranging_pull_in_time_threshold` (2000 code periods) backstops it. It
+also takes `pulled_in` as a conjunct, so "ranging is never ready before the handover is over"
+holds structurally rather than by threshold ordering.
+
+What the backstop relaxes is the *length* of the clean run, not the requirement that the
+channel be clean at all: it fires only with the out-of-lock clock paid down to **zero**. A
+weaker guard — "the clock is within what steady state tolerates" — reads like the one
+`pulled_in`'s timer uses, but the two are not the same test. `pulled_in`'s guard exists to
+stop the *threshold switch itself* from declaring loss, so it is only ever consulted where the
+pull-in allowance exceeds the steady-state one. A health guard has to be reachable instead,
+and the tolerance form is not: the clock can never exceed `elapsed - warm_up_time_threshold`,
+so wherever the dwell outlasts the backstop it cannot fail before the timer fires. The carrier
+detector is exactly that case — a 4000-code-period dwell against a 2000-period backstop — and
+under the tolerance form a channel whose phase-lock indicator had never once passed would be
+admitted to ranging at 2000 code periods, then held there by `resets_on_lock` on one
+favourable chunk in a thousand. Requiring zero is reachable for both detectors (a single
+favourable chunk clears it under `resets_on_lock`, a repaid debt otherwise), cannot be made
+vacuous by any configuration, and keeps the deterministic case the backstop exists for: a
+disturbance recurring faster than the clean run still leaves the clock at zero between
+disturbances, whereas a channel failing steadily enough never to pay its debt off is dropped
+by `is_in_lock` rather than admitted here.
 
 Two code-loop time constants (`1/B_L` = 1000 code periods) rather than anything shorter,
 because the backstop admits a measurement it has not seen clean evidence for, and what the
@@ -194,16 +210,24 @@ The defaults are sized from measured handover transients (see the type's docstri
 1 ms code period, reproduce this receiver's historical absolute timings: an 80 ms warm-up and a
 200 ms steady-state dwell.
 
-`pull_in_out_of_lock_code_periods` is floored at `out_of_lock_code_periods`, so the pull-in
-stage can never be *stricter* than steady state however the steady-state dwell is set. A
-detector whose steady-state dwell already exceeds the pull-in default — the carrier one, at
-4000 code periods — is therefore effectively unstaged, which is correct: it clears its
-accumulator on any favourable chunk, so its dwell already asks for a consecutive run of
-failures far longer than any handover transient.
+Three floors are applied, in the constructor body rather than in the keyword defaults, so
+they hold for every caller rather than only for one that leaves the keyword alone:
 
-`ranging_pull_in_code_periods` is floored at `ranging_confirm_code_periods` for the
-mirror-image reason: a backstop that expired before the evidence path could fire would replace
-the criterion rather than back it up.
+  * `pull_in_out_of_lock_code_periods` is floored at `out_of_lock_code_periods`, so the
+    pull-in stage can never be *stricter* than steady state however the steady-state dwell is
+    set — otherwise `pulled_in` latching would *loosen* the detector and a freshly acquired
+    satellite would be held to a tighter dwell than a converged one. A detector whose
+    steady-state dwell already exceeds the pull-in default — the carrier one, at 4000 code
+    periods — is therefore effectively unstaged, which is correct: it clears its accumulator
+    on any favourable chunk, so its dwell already asks for a consecutive run of failures far
+    longer than any handover transient;
+  * `ranging_confirm_code_periods` is floored at `confirm_code_periods`, since ranging can
+    never be ready before the handover is declared over;
+  * `ranging_pull_in_code_periods` is floored at that *effective* ranging-confirm count — the
+    already-floored one, not the raw keyword — for the mirror-image reason: a backstop that
+    expired before the evidence path could fire would replace the criterion rather than back
+    it up. Flooring against the raw value would miss exactly the case where
+    `confirm_code_periods` is what raised the evidence bar.
 """
 function LockDwell(;
     reference_integration_time,
@@ -213,7 +237,7 @@ function LockDwell(;
     ranging_confirm_code_periods = 600,
     ranging_pull_in_code_periods = 2000,
     out_of_lock_code_periods = 200,
-    pull_in_out_of_lock_code_periods = max(600, out_of_lock_code_periods),
+    pull_in_out_of_lock_code_periods = 600,
     resets_on_lock = false,
 )
     T = code_period_reference(reference_integration_time)
@@ -228,6 +252,17 @@ function LockDwell(;
         pull_in_out_of_lock_code_periods;
         positive = true,
     )
+    # The documented floors, applied here so they bind for every caller — a keyword default
+    # only ever protects the caller who does not pass the keyword. Each one is floored against
+    # the *effective* value of what it is ordered against, so the ordering is transitive: the
+    # backstop follows the ranging-confirm bar that `confirm_code_periods` may itself have
+    # raised, not the raw keyword.
+    staged_out_of_lock_code_periods =
+        max(pull_in_out_of_lock_code_periods, out_of_lock_code_periods)
+    effective_ranging_confirm_code_periods =
+        max(ranging_confirm_code_periods, confirm_code_periods)
+    effective_ranging_pull_in_code_periods =
+        max(ranging_pull_in_code_periods, effective_ranging_confirm_code_periods)
     LockDwell(
         0.0s,
         0.0s,
@@ -237,9 +272,9 @@ function LockDwell(;
         warm_up_code_periods * T,
         pull_in_code_periods * T,
         confirm_code_periods * T,
-        max(ranging_confirm_code_periods, confirm_code_periods) * T,
-        max(ranging_pull_in_code_periods, ranging_confirm_code_periods) * T,
-        pull_in_out_of_lock_code_periods * T,
+        effective_ranging_confirm_code_periods * T,
+        effective_ranging_pull_in_code_periods * T,
+        staged_out_of_lock_code_periods * T,
         out_of_lock_code_periods * T,
         resets_on_lock,
     )
@@ -310,12 +345,20 @@ function update(dwell::LockDwell, is_out_of_lock::Bool, signal_duration)
     # The timer path takes the freshly computed `pulled_in` as a conjunct rather than relying
     # on the thresholds being ordered, so "ranging is never ready before the handover is over"
     # holds structurally however the two timers are configured.
+    #
+    # It also demands a *zero* out-of-lock clock, not merely one inside what steady state
+    # tolerates: the clock can never exceed `elapsed - warm_up_time_threshold`, so the
+    # tolerance form cannot fail before the timer fires wherever the dwell outlasts the
+    # backstop — the carrier detector's 4000-code-period dwell against its 2000-period
+    # backstop is exactly that, and a channel whose indicator never once passed would be
+    # admitted. What the backstop relaxes is the *length* of the clean run, not the
+    # requirement that the channel be clean; see the type's docstring.
     ranging_ready =
         dwell.ranging_ready ||
         (iszero(out_of_lock_time) && settled_time >= dwell.ranging_confirm_time_threshold) ||
         (
             pulled_in &&
-            out_of_lock_time < dwell.out_of_lock_time_threshold &&
+            iszero(out_of_lock_time) &&
             elapsed >= dwell.ranging_pull_in_time_threshold
         )
     LockDwell(
@@ -367,9 +410,9 @@ drop and reacquire it. But while the loops are still walking the coarse acquisit
 in, the code phase — and so the pseudorange — carries a converging bias, measured at tens of
 metres. This latches after `ranging_confirm_time_threshold` of uninterrupted good evidence or,
 for a satellite whose evidence is never uninterrupted, once `ranging_pull_in_time_threshold` of
-signal has elapsed with the out-of-lock clock inside what steady state tolerates. It never
-un-latches: a satellite whose loops settled once has settled, and later disturbances are
-[`is_in_lock`](@ref)'s business — which also means a vector-tracking member carried through an
+signal has elapsed with nothing left on the out-of-lock clock — the backstop shortens the clean
+run it asks for, it does not waive it. It never un-latches: a satellite whose loops settled
+once has settled, and later disturbances are [`is_in_lock`](@ref)'s business — which also means a vector-tracking member carried through an
 outage is immediately rangeable again on return, as it should be, since the navigation filter
 kept both its NCOs steered throughout.
 

--- a/src/lock_detector.jl
+++ b/src/lock_detector.jl
@@ -37,18 +37,363 @@ timings as counts of that period. The fields themselves stay in seconds.
 abstract type AbstractLockDetector end
 
 """
+    LockDwell
+
+The out-of-lock dwell shared by the receiver's lock detectors: a timer that accumulates
+while the detector's statistic reports "no usable signal" and declares lock lost once it
+reaches a threshold. Both [`CodeLockDetector`](@ref) and [`CarrierLockDetector`](@ref) hold
+one, so the handover staging below is defined in exactly one place. Its timings are counts of
+one primary code period — see [`AbstractLockDetector`](@ref) for why.
+
+## Why there are two stages
+
+The acquisition → tracking handover is deliberately coarse: the acquisition Doppler bin is
+sized to half the loop's pull-in range (`receive`'s `pull_in_margin`), and the code phase is
+only resolved to the sample grid, halved by `subsample_interpolation`. The loops need time to
+pull those errors in, and until they have, the prompt correlator sits off the correlation peak
+and carries less power than the satellite really has — so a *healthy* satellite reads below
+its true C/N0, and its carrier phase is still spinning at the residual Doppler, so the
+phase-lock indicator reads near zero.
+
+Measured on synthetic handovers at this receiver's own worst-case residual (see the commit
+that introduced this type), the peak accumulated out-of-lock time a satellite the receiver
+should keep demands is **292 code periods** — GPS L1 C/A at 32 dBHz, a 0.25-chip and 125 Hz
+handover at 2.048 MHz. That is more than the 200-code-period steady-state dwell tolerates, so
+a single un-staged dwell would drop it. The carrier detector's demand is larger again, 460 to
+590 code periods at a healthy 34 dBHz, because the FLL has to pull in the residual Doppler
+before `cos(2φ)` stops averaging to zero.
+
+So the dwell has two stages:
+
+  * **pull-in**, from construction: tolerates `pull_in_out_of_lock_time_threshold`, sized to
+    survive the whole handover transient with margin over the measured worst case;
+  * **steady state**, latched permanently once the handover is over: tolerates the tighter
+    `out_of_lock_time_threshold`.
+
+Two stages rather than one long dwell, because they answer different questions. A single dwell
+would have to be ≳600 code periods to be safe, and would then take three times as long to
+notice a satellite that genuinely disappeared. Staging buys handover tolerance without paying
+for it in steady-state detection latency.
+
+The handover counts as over on *either* of two conditions:
+
+  * `confirm_time_threshold` of uninterrupted favourable evidence with nothing left on the
+    out-of-lock clock — the satellite has demonstrably converged, so there is no reason to
+    keep extending it handover credit;
+  * `pull_in_time_threshold` has elapsed and the accumulated out-of-lock time is under the
+    steady-state threshold — the backstop for a satellite that never quite settles.
+
+Both are needed. Without the evidence-based one, a satellite that converged immediately would
+still be treated as pulling in until the timer expired, and a fade during that window would
+take the *pull-in* dwell to notice. Without the timer, a satellite that never strings together
+a clean run never leaves the stage.
+
+Requiring the accumulated time to be under the steady-state threshold before latching matters
+too: otherwise a satellite sitting comfortably inside the generous pull-in threshold would be
+declared lost the instant the tighter one took over.
+
+One residual case is left open deliberately. Both latches require the out-of-lock clock to be
+under the steady-state threshold, so a satellite whose clock parks *between* the two
+allowances — 200 to 600 code periods — never leaves the pull-in stage, and so never becomes
+ranging-ready either. It takes a burst of failures followed by a sustained near-50% duty
+cycle; stochastically the clock random-walks out of that band, either down to zero (whereupon
+it latches) or past the pull-in allowance (whereupon lock is lost and the satellite is
+reacquired). Closing it would mean letting the pull-in stage latch with its clock still above
+the steady-state threshold, which is exactly the discontinuity the latch guard prevents.
+
+## Why ranging readiness is a separate, later latch
+
+`pulled_in` answers "may the dwell tighten?" and wants to fire *early*, so a fade after a
+successful handover is caught on the steady-state timescale. A pseudorange consumer needs
+something different and slower: the **code loop** to have settled. Those two conflict, and
+measurement shows one threshold cannot serve both.
+
+C/N0 recovers well before the code phase does — on BPSK the prompt only loses `1 − |Δτ|`, so a
+GPS L1 C/A satellite reads healthy almost immediately while its DLL (`1/B_L` = 1000 code
+periods) is still walking the handover error in. Measured at the same 0.25-chip handover, the
+residual code phase is 0.15 to 0.22 chip after 200 code periods — **44 to 64 m of pseudorange
+error** — falling to 0.018 to 0.15 chip, 5 to 44 m, by 600. So there are two latches over the
+same `settled_time`: `confirm_time_threshold` (200 code periods) tightens the dwell, and
+`ranging_confirm_time_threshold` (600) admits the satellite to ranging via
+[`is_ranging_ready`](@ref). It is floored at `confirm_code_periods`, since ranging can never
+be ready before the handover is over.
+
+Being conservative on the second is close to free: the earliest it can fire is the warm-up plus
+one clean run, 680 code periods, and measured on real handovers it lands at 760 to 1500 on GPS
+L1 C/A — the carrier loop has its own residual Doppler to pull in before the phase-lock
+indicator stops resetting the run — so still inside `receive`'s own 2 s
+`time_in_lock_before_calculating_pvt` gate. On slower signals the extra seconds are dwarfed by
+the tens of seconds of subframe decoding that actually set time to first fix.
+
+Like the pull-in stage, ranging readiness needs a *timer* as well as an evidence path, and for
+the same reason: `settled_time` is reset by any out-of-lock verdict, so an uninterrupted run of
+600 is a bar a satellite can fail to clear indefinitely — while sitting comfortably in lock,
+tracked, converged, and silently absent from the PVT solve. Since PVT needs four satellites,
+that trades a degraded fix for no fix.
+
+Under Tracking's default noise-reference CN0 estimator the *code* detector rarely blocks that
+run: measured steady-state per-chunk out-of-lock rates with no handover error are 0.58 at the
+30 dBHz threshold itself, 0.10 one dB above it and 0.00 from two dB up — so a satellite the
+code detector holds at all completes a clean run easily. The **carrier** detector is what
+blocks it: its 460-to-590-code-period pull-in transient resets `settled_time` well after the
+code detector is happy, and any recurring disturbance shorter than the run reopens the same
+hole at any C/N0. So `ranging_pull_in_time_threshold` (2000 code periods) backstops it, under
+the same guard as `pulled_in`'s timer — the out-of-lock clock must be within what steady state
+tolerates, so a channel that is genuinely failing is dropped by `is_in_lock` rather than
+admitted by the timer. It also takes `pulled_in` as a conjunct, so "ranging is never ready
+before the handover is over" holds structurally rather than by threshold ordering.
+
+Two code-loop time constants (`1/B_L` = 1000 code periods) rather than anything shorter,
+because the backstop admits a measurement it has not seen clean evidence for, and what the
+DLL's convergence depends on is *elapsed* time, not clean-run length. What it concedes is
+thermal jitter on a marginal satellite's code phase, not a handover bias: for the default 1 Hz
+code loop and Tracking's 1-chip early-late spacing, Kaplan & Hegarty's coherent-DLL expression
+gives 1σ = 0.039 chip (11 m) at 30 dBHz and 0.027 chip (8 m) at 32, against 0.004 chip (1.2 m)
+at 45 — inside the same band the evidence path already accepts. On GPS L1 C/A the timer is 2 s,
+exactly `receive`'s default `time_in_lock_before_calculating_pvt`, so there it costs nothing.
+
+Before `warm_up_time_threshold` no evidence is accumulated at all. Under the noise-reference
+estimator an unmeasured channel reads `-Inf dBHz` and so *fails* the CN0 test rather than
+passing it, so the warm-up is not there to hide an estimator's cold bias — it is there for the
+carrier detector's own moving averages, which start empty (see [`CarrierLockDetector`](@ref)).
+
+`resets_on_lock` selects how favourable evidence is credited. `false` pays the accumulated time
+back one `signal_duration` at a time. `true` clears it outright, which is the "optimistic"
+detector of Kaplan & Hegarty §5.11.2 — it "decides quickly and changes its mind slowly", so
+declaring loss needs a *consecutive* run of failures. The carrier detector uses it, because a
+marginal satellite's phase-lock indicator dips below threshold intermittently and a paying-back
+accumulator would random-walk across any threshold.
+"""
+struct LockDwell
+    elapsed::typeof(1.0s)
+    out_of_lock_time::typeof(1.0s)
+    # Uninterrupted favourable signal time; reset by any out-of-lock verdict.
+    settled_time::typeof(1.0s)
+    # Latches once the handover transient is over; never returns to the pull-in stage.
+    pulled_in::Bool
+    # Latches once the loops have settled enough to range on — a longer, separate bar, on the
+    # same evidence-or-timer pattern as `pulled_in`; see `is_ranging_ready`.
+    ranging_ready::Bool
+    warm_up_time_threshold::typeof(1.0s)
+    pull_in_time_threshold::typeof(1.0s)
+    confirm_time_threshold::typeof(1.0s)
+    ranging_confirm_time_threshold::typeof(1.0s)
+    ranging_pull_in_time_threshold::typeof(1.0s)
+    pull_in_out_of_lock_time_threshold::typeof(1.0s)
+    out_of_lock_time_threshold::typeof(1.0s)
+    resets_on_lock::Bool
+end
+
+"""
+    LockDwell(; reference_integration_time, kwargs...)
+
+Build a dwell whose timings are the given multiples of `reference_integration_time` — one
+primary code period of the signal the detector runs on.
+
+The defaults are sized from measured handover transients (see the type's docstring) and, for a
+1 ms code period, reproduce this receiver's historical absolute timings: an 80 ms warm-up and a
+200 ms steady-state dwell.
+
+`pull_in_out_of_lock_code_periods` is floored at `out_of_lock_code_periods`, so the pull-in
+stage can never be *stricter* than steady state however the steady-state dwell is set. A
+detector whose steady-state dwell already exceeds the pull-in default — the carrier one, at
+4000 code periods — is therefore effectively unstaged, which is correct: it clears its
+accumulator on any favourable chunk, so its dwell already asks for a consecutive run of
+failures far longer than any handover transient.
+
+`ranging_pull_in_code_periods` is floored at `ranging_confirm_code_periods` for the
+mirror-image reason: a backstop that expired before the evidence path could fire would replace
+the criterion rather than back it up.
+"""
+function LockDwell(;
+    reference_integration_time,
+    warm_up_code_periods = 80,
+    pull_in_code_periods = 800,
+    confirm_code_periods = 200,
+    ranging_confirm_code_periods = 600,
+    ranging_pull_in_code_periods = 2000,
+    out_of_lock_code_periods = 200,
+    pull_in_out_of_lock_code_periods = max(600, out_of_lock_code_periods),
+    resets_on_lock = false,
+)
+    T = code_period_reference(reference_integration_time)
+    check_code_periods(:warm_up_code_periods, warm_up_code_periods)
+    check_code_periods(:pull_in_code_periods, pull_in_code_periods)
+    check_code_periods(:confirm_code_periods, confirm_code_periods)
+    check_code_periods(:ranging_confirm_code_periods, ranging_confirm_code_periods)
+    check_code_periods(:ranging_pull_in_code_periods, ranging_pull_in_code_periods)
+    check_code_periods(:out_of_lock_code_periods, out_of_lock_code_periods; positive = true)
+    check_code_periods(
+        :pull_in_out_of_lock_code_periods,
+        pull_in_out_of_lock_code_periods;
+        positive = true,
+    )
+    LockDwell(
+        0.0s,
+        0.0s,
+        0.0s,
+        false,
+        false,
+        warm_up_code_periods * T,
+        pull_in_code_periods * T,
+        confirm_code_periods * T,
+        max(ranging_confirm_code_periods, confirm_code_periods) * T,
+        max(ranging_pull_in_code_periods, ranging_confirm_code_periods) * T,
+        pull_in_out_of_lock_code_periods * T,
+        out_of_lock_code_periods * T,
+        resets_on_lock,
+    )
+end
+
+# The out-of-lock time currently tolerated: generous while pulling in, tighter once the
+# handover transient has latched closed.
+current_out_of_lock_time_threshold(dwell::LockDwell) =
+    dwell.pulled_in ? dwell.out_of_lock_time_threshold :
+    dwell.pull_in_out_of_lock_time_threshold
+
+current_out_of_lock_time_threshold(lock_detector::AbstractLockDetector) =
+    current_out_of_lock_time_threshold(lock_detector.dwell)
+
+"""
+    update(dwell::LockDwell, is_out_of_lock, signal_duration)
+
+Advance the dwell by `signal_duration` of signal, crediting `is_out_of_lock` as this chunk's
+verdict from the detector's statistic.
+"""
+function update(dwell::LockDwell, is_out_of_lock::Bool, signal_duration)
+    out_of_lock_time = dwell.out_of_lock_time
+    settled_time = dwell.settled_time
+    # Compared before advancing `elapsed`, so the warm-up covers exactly
+    # `warm_up_time_threshold` of signal rather than one chunk less.
+    if dwell.elapsed >= dwell.warm_up_time_threshold
+        if is_out_of_lock
+            # Capped at a small multiple of what the *current stage* tolerates, not of the
+            # steady-state threshold: capping at twice the latter would silently truncate the
+            # pull-in allowance to two thirds of itself. The stage transition needs no special
+            # handling, because both latches require the clock to be under the steady-state
+            # threshold and so under the new stage's cap as well.
+            out_of_lock_time = min(
+                out_of_lock_time + signal_duration,
+                OUT_OF_LOCK_TIME_CAP_FACTOR * current_out_of_lock_time_threshold(dwell),
+            )
+            settled_time = 0.0s
+        else
+            settled_time += signal_duration
+            # Clamped at zero rather than merely guarded above it: paying back a chunk longer
+            # than what is left on the clock would otherwise leave a residue of a few times
+            # `eps` — enough that the `iszero` test below never fires and the detector never
+            # latches out of its pull-in stage.
+            out_of_lock_time =
+                dwell.resets_on_lock ? 0.0s :
+                max(zero(out_of_lock_time), out_of_lock_time - signal_duration)
+        end
+    end
+    elapsed = dwell.elapsed + signal_duration
+    # The handover is over once the satellite has demonstrably converged, or — as a backstop
+    # for one that never quite settles — once its pull-in window has expired. Both require the
+    # out-of-lock clock to be within what steady state will tolerate, so the tighter threshold
+    # taking over cannot itself declare the satellite lost.
+    pulled_in =
+        dwell.pulled_in || (
+            out_of_lock_time < dwell.out_of_lock_time_threshold && (
+                (iszero(out_of_lock_time) && settled_time >= dwell.confirm_time_threshold) ||
+                elapsed >= dwell.pull_in_time_threshold
+            )
+        )
+    # A separate, longer bar than `pulled_in`: the dwell may tighten as soon as the C/N0
+    # deficit is gone, but a pseudorange is only trustworthy once the code loop has settled.
+    # Two conditions, for the same reasons as `pulled_in`'s two — evidence when there is any,
+    # and a timer for the satellite that never strings a clean run together. Without the timer
+    # this bar is one a marginal satellite can fail forever while staying comfortably in lock,
+    # which excludes it from PVT silently and permanently.
+    #
+    # The timer path takes the freshly computed `pulled_in` as a conjunct rather than relying
+    # on the thresholds being ordered, so "ranging is never ready before the handover is over"
+    # holds structurally however the two timers are configured.
+    ranging_ready =
+        dwell.ranging_ready ||
+        (iszero(out_of_lock_time) && settled_time >= dwell.ranging_confirm_time_threshold) ||
+        (
+            pulled_in &&
+            out_of_lock_time < dwell.out_of_lock_time_threshold &&
+            elapsed >= dwell.ranging_pull_in_time_threshold
+        )
+    LockDwell(
+        elapsed,
+        out_of_lock_time,
+        settled_time,
+        pulled_in,
+        ranging_ready,
+        dwell.warm_up_time_threshold,
+        dwell.pull_in_time_threshold,
+        dwell.confirm_time_threshold,
+        dwell.ranging_confirm_time_threshold,
+        dwell.ranging_pull_in_time_threshold,
+        dwell.pull_in_out_of_lock_time_threshold,
+        dwell.out_of_lock_time_threshold,
+        dwell.resets_on_lock,
+    )
+end
+
+is_in_lock(dwell::LockDwell) =
+    dwell.out_of_lock_time < current_out_of_lock_time_threshold(dwell)
+
+"""
+    has_pulled_in(lock_detector::AbstractLockDetector)
+
+Whether the detector has left its pull-in stage — the acquisition → tracking handover is over
+and the satellite is being held to steady-state standards (see [`LockDwell`](@ref)).
+
+This is about the *dwell*, not about measurement quality: it fires as soon as the C/N0 deficit
+of the handover transient has cleared, which on a BPSK signal happens well before the code loop
+has settled. Use [`is_ranging_ready`](@ref) to decide whether to range on the satellite.
+
+The receiver itself gates nothing on this; it is exposed for introspection and diagnostics —
+"which stage is this channel in?" — while [`is_ranging_ready`](@ref) is what actually gates
+ranging (see `collect_pvt_sat_states!`) and [`is_in_lock`](@ref) what gates tracking.
+"""
+has_pulled_in(dwell::LockDwell) = dwell.pulled_in
+has_pulled_in(lock_detector::AbstractLockDetector) = has_pulled_in(lock_detector.dwell)
+
+"""
+    is_ranging_ready(lock_detector::AbstractLockDetector)
+
+Whether the tracking loops have settled enough for this satellite's *measurements* to be
+trustworthy — the question a pseudorange consumer has to ask.
+
+[`is_in_lock`](@ref) answers "should this satellite still be tracked?" and is deliberately
+tolerant through the handover, because the point is to keep a converging satellite rather than
+drop and reacquire it. But while the loops are still walking the coarse acquisition estimate
+in, the code phase — and so the pseudorange — carries a converging bias, measured at tens of
+metres. This latches after `ranging_confirm_time_threshold` of uninterrupted good evidence or,
+for a satellite whose evidence is never uninterrupted, once `ranging_pull_in_time_threshold` of
+signal has elapsed with the out-of-lock clock inside what steady state tolerates. It never
+un-latches: a satellite whose loops settled once has settled, and later disturbances are
+[`is_in_lock`](@ref)'s business — which also means a vector-tracking member carried through an
+outage is immediately rangeable again on return, as it should be, since the navigation filter
+kept both its NCOs steered throughout.
+
+The timer is what keeps a marginal-but-tracked satellite from being excluded from PVT forever;
+see [`LockDwell`](@ref) for the measurements behind both thresholds, and for what the timer
+concedes in exchange (a few metres of extra code-phase jitter, not a handover bias).
+"""
+is_ranging_ready(dwell::LockDwell) = dwell.ranging_ready
+is_ranging_ready(lock_detector::AbstractLockDetector) = is_ranging_ready(lock_detector.dwell)
+
+"""
     CodeLockDetector <: AbstractLockDetector
 
-Declares code lock from the estimated carrier-to-noise density ratio. After a
-`warm_up_code_periods` warm-up it accumulates out-of-lock time whenever the CN0 is below
-`cn0_threshold` (and pays it back down otherwise); lock is lost once the accumulated
-out-of-lock time reaches `out_of_lock_code_periods`. Both timings are counts of
-`reference_integration_time` — see [`AbstractLockDetector`](@ref).
+Declares code lock from the estimated carrier-to-noise density ratio. After a warm-up it
+accumulates out-of-lock time whenever the CN0 is below `cn0_threshold` (and pays it back down
+otherwise); lock is lost once the accumulated out-of-lock time reaches the threshold its
+[`LockDwell`](@ref) stage allows — generous while the loops pull the acquisition handover in,
+tighter in steady state. Every timing is a count of `reference_integration_time`; the dwell's
+keywords are accepted here and forwarded to it.
 
-The accumulated time is capped at twice that threshold. Since it is paid back at the rate
-it is spent, an uncapped dwell would make re-declaring lock take as long as the outage that
-preceded it — minutes, for a satellite kept in tracking through a tunnel by the
-vector-tracking loop. With the cap, one `out_of_lock_time_threshold` of good signal always
+The accumulated time is capped at a small multiple of what the current stage tolerates. Since
+it is paid back at the rate it is spent, an uncapped dwell would make re-declaring lock take as
+long as the outage that preceded it — minutes, for a satellite kept in tracking through a
+tunnel by the vector-tracking loop. With the cap, one stage threshold of good signal always
 brings a satellite back.
 
 The comparison is made on the *post-integration* SNR, `CN0 · T`, rather than on CN0
@@ -120,10 +465,7 @@ struct CodeLockDetector <: AbstractLockDetector
     cn0_threshold::typeof(1.0dBHz)
     reference_integration_time::typeof(1.0s)
     coherence_limit::typeof(1.0s)
-    out_of_lock_time::typeof(1.0s)
-    out_of_lock_time_threshold::typeof(1.0s)
-    wait_time::typeof(1.0s)
-    wait_time_threshold::typeof(1.0s)
+    dwell::LockDwell
 end
 
 function CodeLockDetector(;
@@ -132,22 +474,15 @@ function CodeLockDetector(;
     # see `primary_code_period` and the `ReceiverSatState` constructors.
     reference_integration_time = 1ms,
     coherence_limit = Inf * s,
-    out_of_lock_code_periods = 200,
-    warm_up_code_periods = 80,
+    dwell_kwargs...,
 )
-    # `reference_integration_time` may arrive as `Tracking`'s `Hz^-1`; normalise once so
-    # every stored duration is in seconds.
-    T = code_period_reference(reference_integration_time)
-    check_code_periods(:out_of_lock_code_periods, out_of_lock_code_periods; positive = true)
-    check_code_periods(:warm_up_code_periods, warm_up_code_periods)
     CodeLockDetector(
         cn0_threshold,
-        T,
+        # `reference_integration_time` may arrive as `Tracking`'s `Hz^-1`; normalise once so
+        # every stored duration is in seconds.
+        code_period_reference(reference_integration_time),
         coherence_limit,
-        0.0s,
-        out_of_lock_code_periods * T,
-        0.0s,
-        warm_up_code_periods * T,
+        LockDwell(; reference_integration_time, dwell_kwargs...),
     )
 end
 
@@ -200,7 +535,7 @@ function is_below_cn0_threshold(lock_detector::CodeLockDetector, cn0, integratio
     !(snr >= required)
 end
 
-# How far above `out_of_lock_time_threshold` the accumulated out-of-lock time may run. The
+# How far above the current stage's threshold the accumulated out-of-lock time may run. The
 # dwell is paid back one-for-one, so without a cap the time to *re*-declare lock is the full
 # length of the outage that came before it: a satellite obscured for a minute would need a
 # minute of clean signal to come back. That contradicts what the dwell is for — riding out
@@ -212,47 +547,39 @@ end
 const OUT_OF_LOCK_TIME_CAP_FACTOR = 2
 
 function update(lock_detector::CodeLockDetector, cn0, integration_time, signal_duration)
-    out_of_lock_time = lock_detector.out_of_lock_time
-    if lock_detector.wait_time >= lock_detector.wait_time_threshold
-        if is_below_cn0_threshold(lock_detector, cn0, integration_time)
-            out_of_lock_time = min(
-                out_of_lock_time + signal_duration,
-                OUT_OF_LOCK_TIME_CAP_FACTOR * lock_detector.out_of_lock_time_threshold,
-            )
-        elseif out_of_lock_time > 0.0s
-            out_of_lock_time -= signal_duration
-        end
-    end
-    CodeLockDetector(
-        lock_detector.cn0_threshold,
-        lock_detector.reference_integration_time,
-        lock_detector.coherence_limit,
-        out_of_lock_time,
-        lock_detector.out_of_lock_time_threshold,
-        min(lock_detector.wait_time + signal_duration, lock_detector.wait_time_threshold),
-        lock_detector.wait_time_threshold,
+    @set lock_detector.dwell = update(
+        lock_detector.dwell,
+        is_below_cn0_threshold(lock_detector, cn0, integration_time),
+        signal_duration,
     )
 end
 
 """
     is_in_lock(lock_detector::AbstractLockDetector)
 
-Return `true` while the detector's accumulated out-of-lock time is below its threshold.
+Return `true` while the detector's accumulated out-of-lock time is below the threshold its
+current stage allows (see [`LockDwell`](@ref)).
 """
-function is_in_lock(lock_detector::AbstractLockDetector)
-    lock_detector.out_of_lock_time < lock_detector.out_of_lock_time_threshold
-end
+is_in_lock(lock_detector::AbstractLockDetector) = is_in_lock(lock_detector.dwell)
 
 """
     set_out_of_lock(lock_detector::AbstractLockDetector)
 
-Return a copy of the detector with its accumulated out-of-lock time raised to the
-threshold, so [`is_in_lock`](@ref) immediately reports `false`. Used to force a
-satellite out of lock, e.g. when vector tracking releases it for cause.
+Return a copy of the detector with its accumulated out-of-lock time raised to the threshold
+its *current stage* allows, so [`is_in_lock`](@ref) immediately reports `false`. Used to force
+a satellite out of lock, e.g. when vector tracking releases it for cause
+(`force_out_of_lock`) — which silently no-ops unless the lock verdict flips on the spot, so
+raising it to the fixed steady-state value would not do: a satellite still in its pull-in stage
+tolerates three times that.
+
+`pulled_in` is deliberately left alone. A released satellite is removed from tracking on the
+next chunk and reacquired with a fresh detector, so demoting the flag buys nothing and would
+muddy its meaning.
 """
-function set_out_of_lock(lock_detector::AbstractLockDetector)
-    @set lock_detector.out_of_lock_time = lock_detector.out_of_lock_time_threshold
-end
+set_out_of_lock(dwell::LockDwell) =
+    @set dwell.out_of_lock_time = current_out_of_lock_time_threshold(dwell)
+set_out_of_lock(lock_detector::AbstractLockDetector) =
+    @set lock_detector.dwell = set_out_of_lock(lock_detector.dwell)
 
 """
     CarrierLockDetector <: AbstractLockDetector
@@ -272,11 +599,13 @@ phase error `φ`,
 E[Iₖ² − Qₖ²] = A²·cos(2φ)      E[Iₖ² + Qₖ²] = A² + σ²
 ```
 
-so `E[PLI] = cos(2φ)·ρ/(ρ+1)`. Lock is declared while `PLI ≥ phase_lock_threshold`; the
-out-of-lock dwell clears outright on any favourable chunk, so declaring loss needs a
-*consecutive* run of failures. Its default `out_of_lock_code_periods` of 4000 is 4 s on
-GPS L1 C/A, matching both this receiver's historical value and Ward's
-`L0 = 240 × 20 ms = 4.8 s`.
+so `E[PLI] = cos(2φ)·ρ/(ρ+1)`. Lock is declared while `PLI ≥ phase_lock_threshold`; its
+[`LockDwell`](@ref) clears outright on any favourable chunk (`resets_on_lock`), so declaring
+loss needs a *consecutive* run of failures. Its default `out_of_lock_code_periods` of 4000 is
+4 s on GPS L1 C/A, matching both this receiver's historical value and Ward's
+`L0 = 240 × 20 ms = 4.8 s`. Because `pull_in_out_of_lock_code_periods` is floored at that,
+both stages are equal and the carrier detector is deliberately unstaged — its dwell already
+asks for a consecutive run of failures far longer than any handover transient.
 
 This replaces a low-pass-filtered `|I|`-versus-`|Q|` amplitude comparison
 (`lowpass(|I|)/K2 > lowpass(|Q|)` with `K1 = 0.0247`, `K2 = 1.5` — the detector of
@@ -336,10 +665,7 @@ struct CarrierLockDetector <: AbstractLockDetector
     filtered_total_power::Float64
     smoothing_gain::Float64
     phase_lock_threshold::Float64
-    out_of_lock_time::typeof(1.0s)
-    out_of_lock_time_threshold::typeof(1.0s)
-    wait_time::typeof(1.0s)
-    wait_time_threshold::typeof(1.0s)
+    dwell::LockDwell
 end
 
 function CarrierLockDetector(;
@@ -347,11 +673,8 @@ function CarrierLockDetector(;
     phase_lock_threshold = 0.25,
     smoothing_records = 200,
     out_of_lock_code_periods = 4000,
-    warm_up_code_periods = 80,
+    dwell_kwargs...,
 )
-    T = code_period_reference(reference_integration_time)
-    check_code_periods(:out_of_lock_code_periods, out_of_lock_code_periods; positive = true)
-    check_code_periods(:warm_up_code_periods, warm_up_code_periods)
     # A window shorter than one record gives a gain above 1, which makes the "moving average"
     # overshoot every sample; a window of 0 gives an infinite gain, which turns both averages
     # into `NaN` on the first prompt. `is_below_phase_lock_threshold` reads a non-finite
@@ -383,10 +706,12 @@ function CarrierLockDetector(;
         0.0,
         1 / smoothing_records,
         phase_lock_threshold,
-        0.0s,
-        out_of_lock_code_periods * T,
-        0.0s,
-        warm_up_code_periods * T,
+        LockDwell(;
+            reference_integration_time,
+            out_of_lock_code_periods,
+            resets_on_lock = true,
+            dwell_kwargs...,
+        ),
     )
 end
 
@@ -418,8 +743,8 @@ end
 """
     update(lock_detector::CarrierLockDetector, prompts, signal_duration)
 
-Fold every prompt of one processing chunk into the indicator, then advance the timers once
-by `signal_duration`.
+Fold every prompt of one processing chunk into the indicator, then advance the dwell once by
+`signal_duration`.
 
 `prompts` is the whole sequence of filtered prompt correlator values the chunk produced
 (Tracking's `get_filtered_prompts`), not just the last one: at the receiver's default 4 ms
@@ -444,31 +769,10 @@ function update(lock_detector::CarrierLockDetector, prompts, signal_duration)
         total,
         K,
         lock_detector.phase_lock_threshold,
-        lock_detector.out_of_lock_time,
-        lock_detector.out_of_lock_time_threshold,
-        lock_detector.wait_time,
-        lock_detector.wait_time_threshold,
+        lock_detector.dwell,
     )
-    out_of_lock_time = lock_detector.out_of_lock_time
-    if lock_detector.wait_time >= lock_detector.wait_time_threshold
-        # Cleared outright rather than paid back one-for-one: this is the "optimistic"
-        # detector of Kaplan & Hegarty §5.11.2, which "decides quickly and changes its mind
-        # slowly". A marginal satellite's indicator dips below threshold intermittently, and
-        # a paying-back accumulator would random-walk across any threshold.
-        out_of_lock_time =
-            is_below_phase_lock_threshold(measured) ? out_of_lock_time + signal_duration :
-            0.0s
-    end
-    CarrierLockDetector(
-        coherent,
-        total,
-        K,
-        lock_detector.phase_lock_threshold,
-        out_of_lock_time,
-        lock_detector.out_of_lock_time_threshold,
-        min(lock_detector.wait_time + signal_duration, lock_detector.wait_time_threshold),
-        lock_detector.wait_time_threshold,
-    )
+    @set measured.dwell =
+        update(lock_detector.dwell, is_below_phase_lock_threshold(measured), signal_duration)
 end
 
 update(lock_detector::CarrierLockDetector, prompt::Complex, signal_duration) =

--- a/src/lock_detector.jl
+++ b/src/lock_detector.jl
@@ -9,6 +9,30 @@ The detectors track elapsed signal time rather than a number of `update` calls, 
 their behaviour is independent of how the incoming signal is chunked: each `update`
 is handed the `signal_duration` it represents and accumulates that duration into its
 timers.
+
+## Why the timings are in primary code periods, not seconds
+
+`Tracking` sizes its default loop bandwidths from the primary code period `T`, at
+`B_L·T ≈ 0.018`: `B_L = 0.018/T` for the carrier loop and `B_L/18` for the code loop. So
+every loop time constant scales with `T` — `1/B_L` is `55.6·T` for the carrier and
+`1000·T` for the code loop:
+
+| signal | `T` | carrier `B_L` | code `B_L` | `1/B_L` carrier | `1/B_L` code |
+|---|---|---|---|---|---|
+| GPS L1 C/A | 1 ms | 18 Hz | 1 Hz | 56 ms | 1.0 s |
+| Galileo E1B | 4 ms | 4.5 Hz | 0.25 Hz | 222 ms | 4.0 s |
+| GPS L1C-D | 10 ms | 1.8 Hz | 0.1 Hz | 556 ms | 10.0 s |
+
+A dwell fixed in *seconds* therefore means something different on every signal. The 200 ms
+this receiver used to allow is 200 code periods on GPS L1 C/A — enough — but only 50 on
+Galileo E1B and 20 on GPS L1C-D, against loops that are 4× and 10× slower. That is why lock
+detection failed on the slower signals while GPS L1 C/A looked fine. Counted in code
+periods the same number means the same thing everywhere, and the GPS L1 C/A defaults are
+reproduced exactly (`T = 1 ms`, so 200 code periods *is* 200 ms).
+
+So every detector takes a `reference_integration_time` — one primary code period of the
+signal it runs on, which the receiver passes from `primary_code_period` — and takes its
+timings as counts of that period. The fields themselves stay in seconds.
 """
 abstract type AbstractLockDetector end
 
@@ -16,9 +40,10 @@ abstract type AbstractLockDetector end
     CodeLockDetector <: AbstractLockDetector
 
 Declares code lock from the estimated carrier-to-noise density ratio. After a
-`wait_time_threshold` warm-up it accumulates out-of-lock time whenever the CN0 is below
+`warm_up_code_periods` warm-up it accumulates out-of-lock time whenever the CN0 is below
 `cn0_threshold` (and pays it back down otherwise); lock is lost once the accumulated
-out-of-lock time reaches `out_of_lock_time_threshold`.
+out-of-lock time reaches `out_of_lock_code_periods`. Both timings are counts of
+`reference_integration_time` — see [`AbstractLockDetector`](@ref).
 
 The accumulated time is capped at twice that threshold. Since it is paid back at the rate
 it is spent, an uncapped dwell would make re-declaring lock take as long as the outage that
@@ -87,8 +112,9 @@ the first measurement rather than a configuration a user can land in. At four or
 antennas the same `-Inf` can extend over the first chunk or two, while the array's spatial
 noise covariance is still rank-deficient in its own dimensions — and only for a receiver
 fed buffers of about one code period, since a longer chunk clears it within its first call.
-Either way the detector's own warm-up (`wait_time_threshold`, 80 ms) is orders of magnitude
-longer, so it never accumulates against it.
+Either way the detector's own warm-up (`warm_up_code_periods`, 80 code periods) is orders of
+magnitude longer — on every signal, since it scales with the code period too — so it never
+accumulates against it.
 """
 struct CodeLockDetector <: AbstractLockDetector
     cn0_threshold::typeof(1.0dBHz)
@@ -106,18 +132,51 @@ function CodeLockDetector(;
     # see `primary_code_period` and the `ReceiverSatState` constructors.
     reference_integration_time = 1ms,
     coherence_limit = Inf * s,
-    out_of_lock_time_threshold = 200ms,
-    wait_time_threshold = 80ms,
+    out_of_lock_code_periods = 200,
+    warm_up_code_periods = 80,
 )
+    # `reference_integration_time` may arrive as `Tracking`'s `Hz^-1`; normalise once so
+    # every stored duration is in seconds.
+    T = code_period_reference(reference_integration_time)
+    check_code_periods(:out_of_lock_code_periods, out_of_lock_code_periods; positive = true)
+    check_code_periods(:warm_up_code_periods, warm_up_code_periods)
     CodeLockDetector(
         cn0_threshold,
-        reference_integration_time,
+        T,
         coherence_limit,
         0.0s,
-        out_of_lock_time_threshold,
+        out_of_lock_code_periods * T,
         0.0s,
-        wait_time_threshold,
+        warm_up_code_periods * T,
     )
+end
+
+# One primary code period, normalised to seconds. Every detector timing is a multiple of it.
+function code_period_reference(reference_integration_time)
+    T = uconvert(s, reference_integration_time)
+    T > zero(T) && isfinite(ustrip(T)) || throw(
+        ArgumentError(
+            "reference_integration_time must be a finite, positive duration — it is one " *
+            "primary code period of the signal the detector runs on — got $T",
+        ),
+    )
+    T
+end
+
+# Reject a code-period count that cannot describe a timing before it is silently scaled into
+# one: a negative count scales into a negative threshold, and `out_of_lock_time < threshold`
+# would then be false from the first update, so the channel would be dead on arrival rather
+# than loudly misconfigured. The dwells have to be *strictly* positive for the same reason —
+# `is_in_lock` tests `<`, so a zero threshold is never satisfied. A warm-up may legitimately
+# be zero. `NaN` fails both comparisons, so it is caught here too.
+function check_code_periods(name::Symbol, value; positive::Bool = false)
+    isfinite(value) && (positive ? value > 0 : value >= 0) || throw(
+        ArgumentError(
+            "$name must be a finite, $(positive ? "strictly positive" : "non-negative") " *
+            "number of code periods, got $value",
+        ),
+    )
+    value
 end
 
 # Post-integration SNR of the last fully integrated record against the SNR
@@ -199,10 +258,16 @@ end
     CarrierLockDetector <: AbstractLockDetector
 
 Declares carrier lock from the prompt correlator using the standard low-pass filtered
-in-phase/quadrature amplitude test. Over each `integration_time_threshold` block it
+in-phase/quadrature amplitude test. Over each `integration_code_periods` block it
 compares the filtered in-phase amplitude against the filtered quadrature amplitude; too
 little in-phase dominance accumulates out-of-lock time, and lock is lost once it reaches
-`out_of_lock_time_threshold`.
+`out_of_lock_code_periods`.
+
+As for [`CodeLockDetector`](@ref), all three timings are counts of
+`reference_integration_time` — one primary code period of the signal the detector runs on
+(see [`AbstractLockDetector`](@ref)). The defaults reproduce this receiver's historical
+absolute values on GPS L1 C/A, whose code period is 1 ms: a 4 s dwell and an 80 ms warm-up
+and integration block.
 """
 struct CarrierLockDetector <: AbstractLockDetector
     prev_filtered_inphase::Float64
@@ -216,19 +281,28 @@ struct CarrierLockDetector <: AbstractLockDetector
 end
 
 function CarrierLockDetector(;
-    out_of_lock_time_threshold = 4s,
-    wait_time_threshold = 80ms,
-    integration_time_threshold = 80ms,
+    reference_integration_time = 1ms,
+    out_of_lock_code_periods = 4000,
+    warm_up_code_periods = 80,
+    integration_code_periods = 80,
 )
+    T = code_period_reference(reference_integration_time)
+    check_code_periods(:out_of_lock_code_periods, out_of_lock_code_periods; positive = true)
+    check_code_periods(:warm_up_code_periods, warm_up_code_periods)
+    check_code_periods(
+        :integration_code_periods,
+        integration_code_periods;
+        positive = true,
+    )
     CarrierLockDetector(
         0.0,
         0.0,
         0.0s,
-        integration_time_threshold,
+        integration_code_periods * T,
         0.0s,
-        out_of_lock_time_threshold,
+        out_of_lock_code_periods * T,
         0.0s,
-        wait_time_threshold,
+        warm_up_code_periods * T,
     )
 end
 

--- a/src/lock_detector.jl
+++ b/src/lock_detector.jl
@@ -257,23 +257,85 @@ end
 """
     CarrierLockDetector <: AbstractLockDetector
 
-Declares carrier lock from the prompt correlator using the standard low-pass filtered
-in-phase/quadrature amplitude test. Over each `integration_code_periods` block it
-compares the filtered in-phase amplitude against the filtered quadrature amplitude; too
-little in-phase dominance accumulates out-of-lock time, and lock is lost once it reaches
-`out_of_lock_code_periods`.
+Declares carrier lock from the prompt correlator using the Van Dierendonck
+narrowband-difference / narrowband-power phase-lock indicator
 
-As for [`CodeLockDetector`](@ref), all three timings are counts of
-`reference_integration_time` — one primary code period of the signal the detector runs on
-(see [`AbstractLockDetector`](@ref)). The defaults reproduce this receiver's historical
-absolute values on GPS L1 C/A, whose code period is 1 ms: a 4 s dwell and an 80 ms warm-up
-and integration block.
+```
+PLI = Σ(Iₖ² − Qₖ²) / Σ(Iₖ² + Qₖ²)
+```
+
+accumulated over every prompt the tracking loops produce. For a prompt of amplitude `A`
+in noise of total variance `σ²` — post-integration SNR `ρ = A²/σ² = CN0·T` — at carrier
+phase error `φ`,
+
+```
+E[Iₖ² − Qₖ²] = A²·cos(2φ)      E[Iₖ² + Qₖ²] = A² + σ²
+```
+
+so `E[PLI] = cos(2φ)·ρ/(ρ+1)`. Lock is declared while `PLI ≥ phase_lock_threshold`; the
+out-of-lock dwell clears outright on any favourable chunk, so declaring loss needs a
+*consecutive* run of failures. Its default `out_of_lock_code_periods` of 4000 is 4 s on
+GPS L1 C/A, matching both this receiver's historical value and Ward's
+`L0 = 240 × 20 ms = 4.8 s`.
+
+This replaces a low-pass-filtered `|I|`-versus-`|Q|` amplitude comparison
+(`lowpass(|I|)/K2 > lowpass(|Q|)` with `K1 = 0.0247`, `K2 = 1.5` — the detector of
+Kaplan & Hegarty §5.11.2). Three concrete reasons:
+
+  * **It sees every prompt.** The old detector was fed one prompt per processing chunk,
+    discarding three of every four at the receiver's 4 ms chunk over a 1 ms code period.
+  * **Its averaging is continuous.** The old filter state was reset every 80 ms block, so
+    the value actually tested had only reached ~39% of its asymptote — `K1 = 0.0247` is
+    specified for 20 ms epochs and gives a 40-epoch time constant, which the 20-update
+    block truncated.
+  * **Its expectation is known in closed form**, so a threshold maps to an explicit phase
+    error at a given C/N0. The old comparison only approaches a phase test at high SNR;
+    at low SNR it degenerates into an implicit SNR test (at perfect phase lock it flips at
+    `ρ ≈ 0.54`, i.e. ~27.4 dBHz over a 1 ms record), and that crossover is a consequence of
+    `K2` rather than something you can read off it.
+
+`phase_lock_threshold` defaults to `0.25`, matching PocketSDR's `THRES_PLI`. Because the
+indicator saturates at `ρ/(ρ+1)`, a threshold has to be read together with the C/N0 one: at
+the default 30 dBHz over a 1 ms record `ρ = 1`, so even perfect phase lock reads only `0.5`,
+and `0.25` demands `cos(2φ) ≥ 0.5` — `|φ| ≤ 30°`, comparable to the 33.7° `K2 = 1.5`
+implied. A threshold above `0.5` would be unreachable at the C/N0 the code detector still
+accepts. Read as a pure sensitivity floor the default is `ρ ≥ 1/3`, i.e. 25.2 dBHz at a 1 ms
+record, so — as before — the code detector's 30 dBHz stays the binding limit and the carrier
+detector is left to judge phase.
+
+The two sums are tracked as exponential moving averages sharing one gain, so the indicator
+is continuous. `smoothing_records` sets the averaging window; the default of 200 keeps the
+noise-only indicator's median at 0.00 and its 99th percentile at 0.12 — both well clear of
+the 0.25 threshold — while a 36 dBHz signal reads 0.78 against its 0.80 asymptote.
+
+The window is counted in **records, not code periods**, unlike the two timings: the gain is
+applied once per prompt, and a prompt is one record spanning
+`get_last_fully_integrated_num_code_blocks` code blocks. The timings stay honest in code
+periods because they are driven by `signal_duration`, which is real elapsed time; this
+average has no access to that. The two coincide today only because Tracking's
+`preferred_num_code_blocks_to_integrate` is 1 and this receiver never raises it (see
+[`CodeLockDetector`](@ref)) — once that is plumbed through, a 200-record window will be
+200·N code periods long.
+
+Those noise-only figures are **asymptotic**, and the 80-code-period warm-up is shorter than
+the 200-record window, so the first judgement is made on an average that has not converged.
+Measured over 4000 noise realizations at the default window, the p99 settles at 0.12 but is
+0.17 at 200 records, 0.26 at 80 (max 0.38) and 0.35 at 40 — i.e. at the moment the warm-up
+ends a noise-only channel is above threshold 1.2% of the time. The warm-up is deliberately
+*not* lengthened to match: clearing the dwell on any favourable chunk, together with the
+4000-code-period dwell, means declaring loss needs a consecutive run of failures, so an
+early excursion in either direction is absorbed. In the other direction the early window is
+already tight enough: at the code-lock threshold (`ρ = 1`, perfect phase lock) the indicator
+is below 0.25 for 0.1% of realizations at 80 records and none at 200.
 """
 struct CarrierLockDetector <: AbstractLockDetector
-    prev_filtered_inphase::Float64
-    prev_filtered_quadrature::Float64
-    integration_time::typeof(1.0s)
-    integration_time_threshold::typeof(1.0s)
+    # Exponential moving averages of I² − Q² and I² + Q², sharing `smoothing_gain`. The gain
+    # is applied once per *record*, so — unlike the two timings below — the window it implies
+    # is a count of records rather than of code periods.
+    filtered_coherent_power::Float64
+    filtered_total_power::Float64
+    smoothing_gain::Float64
+    phase_lock_threshold::Float64
     out_of_lock_time::typeof(1.0s)
     out_of_lock_time_threshold::typeof(1.0s)
     wait_time::typeof(1.0s)
@@ -282,23 +344,45 @@ end
 
 function CarrierLockDetector(;
     reference_integration_time = 1ms,
+    phase_lock_threshold = 0.25,
+    smoothing_records = 200,
     out_of_lock_code_periods = 4000,
     warm_up_code_periods = 80,
-    integration_code_periods = 80,
 )
     T = code_period_reference(reference_integration_time)
     check_code_periods(:out_of_lock_code_periods, out_of_lock_code_periods; positive = true)
     check_code_periods(:warm_up_code_periods, warm_up_code_periods)
-    check_code_periods(
-        :integration_code_periods,
-        integration_code_periods;
-        positive = true,
+    # A window shorter than one record gives a gain above 1, which makes the "moving average"
+    # overshoot every sample; a window of 0 gives an infinite gain, which turns both averages
+    # into `NaN` on the first prompt. `is_below_phase_lock_threshold` reads a non-finite
+    # average as out of lock — correctly, for a dead correlator — so the channel would then be
+    # silently dead from construction rather than loudly misconfigured.
+    isfinite(smoothing_records) && smoothing_records >= 1 || throw(
+        ArgumentError(
+            "smoothing_records is the averaging window in records and sets the moving " *
+            "averages' gain to 1/smoothing_records, so it must be a finite number ≥ 1, " *
+            "got $smoothing_records",
+        ),
+    )
+    # The indicator is `cos(2φ)·ρ/(ρ+1)`, so it lives in `[-1, 1]`: a threshold at or above 1
+    # is unreachable at any C/N0 and holds the channel permanently out of lock, one at or
+    # below −1 is met by anything and never reports loss. In practice the ceiling is lower
+    # still — the indicator saturates at `ρ/(ρ+1)`, which is 0.5 at the 30 dBHz the code
+    # detector accepts over a one-block record — but that bound moves with the record length,
+    # so only the mathematical one is enforced.
+    isfinite(phase_lock_threshold) && -1 < phase_lock_threshold < 1 || throw(
+        ArgumentError(
+            "phase_lock_threshold is compared against cos(2φ)·ρ/(ρ+1) ∈ [-1, 1], so it " *
+            "must be strictly inside that range (and below ρ/(ρ+1) ≈ 0.5 at the code " *
+            "detector's own 30 dBHz over a one-block record to be reachable at all), got " *
+            "$phase_lock_threshold",
+        ),
     )
     CarrierLockDetector(
         0.0,
         0.0,
-        0.0s,
-        integration_code_periods * T,
+        1 / smoothing_records,
+        phase_lock_threshold,
         0.0s,
         out_of_lock_code_periods * T,
         0.0s,
@@ -306,38 +390,86 @@ function CarrierLockDetector(;
     )
 end
 
-function update(lock_detector::CarrierLockDetector, prompt, signal_duration)
-    K1 = 0.0247
-    K2 = 1.5
-    next_filtered_inphase =
-        (abs(real(prompt)) - lock_detector.prev_filtered_inphase) * K1 +
-        lock_detector.prev_filtered_inphase
-    next_filtered_quadrature =
-        (abs(imag(prompt)) - lock_detector.prev_filtered_quadrature) * K1 +
-        lock_detector.prev_filtered_quadrature
+"""
+    phase_lock_indicator(lock_detector::CarrierLockDetector)
 
+The smoothed phase-lock indicator, or `NaN` before any prompt has been folded in.
+"""
+phase_lock_indicator(lock_detector::CarrierLockDetector) =
+    lock_detector.filtered_total_power > 0 ?
+    lock_detector.filtered_coherent_power / lock_detector.filtered_total_power : NaN
+
+function is_below_phase_lock_threshold(lock_detector::CarrierLockDetector)
+    # A non-finite moving average means a non-finite prompt reached the detector — a dead or
+    # saturated correlator channel. That has to fail *closed*, exactly as a non-finite CN0
+    # does in `is_below_cn0_threshold`: `NaN` poisons both averages permanently, and since
+    # `NaN > 0` is `false` it would otherwise look like "nothing measured yet" forever and
+    # hold the channel in lock indefinitely.
+    (
+        isfinite(lock_detector.filtered_total_power) &&
+        isfinite(lock_detector.filtered_coherent_power)
+    ) || return true
+    # Genuinely nothing folded in yet: the warm-up owns that window, so not out of lock.
+    lock_detector.filtered_total_power > 0 || return false
+    # Negated `>=` so any remaining non-finite indicator counts as out of lock too.
+    !(phase_lock_indicator(lock_detector) >= lock_detector.phase_lock_threshold)
+end
+
+"""
+    update(lock_detector::CarrierLockDetector, prompts, signal_duration)
+
+Fold every prompt of one processing chunk into the indicator, then advance the timers once
+by `signal_duration`.
+
+`prompts` is the whole sequence of filtered prompt correlator values the chunk produced
+(Tracking's `get_filtered_prompts`), not just the last one: at the receiver's default 4 ms
+chunk over a 1 ms code period, reading only `get_last_fully_integrated_filtered_prompt`
+would discard three of every four. A lone prompt is accepted too, for callers that have
+only one. An empty sequence — a chunk too short to complete a record — advances the timers
+without inventing evidence.
+"""
+function update(lock_detector::CarrierLockDetector, prompts, signal_duration)
+    coherent = lock_detector.filtered_coherent_power
+    total = lock_detector.filtered_total_power
+    K = lock_detector.smoothing_gain
+    for prompt in prompts
+        inphase_power, quadrature_power = real(prompt)^2, imag(prompt)^2
+        coherent += K * (inphase_power - quadrature_power - coherent)
+        total += K * (inphase_power + quadrature_power - total)
+    end
+    # The verdict is read off the *updated* averages, so a chunk is judged on everything it
+    # contributed rather than on the state that preceded it.
+    measured = CarrierLockDetector(
+        coherent,
+        total,
+        K,
+        lock_detector.phase_lock_threshold,
+        lock_detector.out_of_lock_time,
+        lock_detector.out_of_lock_time_threshold,
+        lock_detector.wait_time,
+        lock_detector.wait_time_threshold,
+    )
     out_of_lock_time = lock_detector.out_of_lock_time
-    next_integration_time = lock_detector.integration_time + signal_duration
-    if next_integration_time >= lock_detector.integration_time_threshold
-        if lock_detector.wait_time >= lock_detector.wait_time_threshold
-            if next_filtered_inphase / K2 < next_filtered_quadrature
-                out_of_lock_time += next_integration_time
-            else
-                out_of_lock_time = 0.0s
-            end
-        end
-        next_filtered_inphase = 0.0
-        next_filtered_quadrature = 0.0
-        next_integration_time = 0.0s
+    if lock_detector.wait_time >= lock_detector.wait_time_threshold
+        # Cleared outright rather than paid back one-for-one: this is the "optimistic"
+        # detector of Kaplan & Hegarty §5.11.2, which "decides quickly and changes its mind
+        # slowly". A marginal satellite's indicator dips below threshold intermittently, and
+        # a paying-back accumulator would random-walk across any threshold.
+        out_of_lock_time =
+            is_below_phase_lock_threshold(measured) ? out_of_lock_time + signal_duration :
+            0.0s
     end
     CarrierLockDetector(
-        next_filtered_inphase,
-        next_filtered_quadrature,
-        next_integration_time,
-        lock_detector.integration_time_threshold,
+        coherent,
+        total,
+        K,
+        lock_detector.phase_lock_threshold,
         out_of_lock_time,
         lock_detector.out_of_lock_time_threshold,
         min(lock_detector.wait_time + signal_duration, lock_detector.wait_time_threshold),
         lock_detector.wait_time_threshold,
     )
 end
+
+update(lock_detector::CarrierLockDetector, prompt::Complex, signal_duration) =
+    update(lock_detector, (prompt,), signal_duration)

--- a/src/process.jl
+++ b/src/process.jl
@@ -464,12 +464,21 @@ function remove_lost_satellites(receiver_sat_states, track_state)
 end
 
 # Append the PVT-ready satellites of the given `systems` (every constellation
-# across all bands) to `states`. A satellite is ready once it is in lock and has
-# been in lock for `time_in_lock_before_calculating_pvt` — long enough for its
-# loops to have settled onto the signal, so the code phase the pseudorange is
-# built from is the tracked one and not a pull-in transient. Called by the
-# combined multi-band PVT solve (`update_pvt`); `calc_pvt` itself further filters
-# to satellites whose navigation data is fully decoded and healthy.
+# across all bands) to `states`. A satellite is ready once it is in lock, its loops have
+# settled enough to range on (`is_ranging_ready`), and it has been in lock for
+# `time_in_lock_before_calculating_pvt` — long enough to have decoded usable data. Called by
+# the combined multi-band PVT solve (`update_pvt`); `calc_pvt` itself further filters to
+# satellites whose navigation data is fully decoded and healthy.
+#
+# The `is_ranging_ready` gate is what keeps the lock detectors' tolerance through the
+# acquisition → tracking handover from costing accuracy. `is_in_lock` is deliberately generous
+# there — the whole point is to keep a converging satellite rather than drop and reacquire it —
+# but while the loops are still walking the coarse acquisition estimate in, the code phase
+# carries a converging bias, and a pseudorange built from it is wrong by tens of metres
+# (measured on a 0.25-chip handover: 44-64 m at 200 code periods, 5-44 m at 600).
+# `time_in_lock_before_calculating_pvt` alone does not cover this: it counts from the handover,
+# so it can elapse while the loops are still settling — and on a code longer than 1 ms the
+# settling takes proportionally longer while that gate stays fixed in seconds.
 function collect_pvt_sat_states!(
     states,
     systems,
@@ -481,6 +490,7 @@ function collect_pvt_sat_states!(
         group_key = signal_group_key(system)
         for receiver_sat_state in receiver_sat_states[group_key]
             if is_in_lock(receiver_sat_state) &&
+               is_ranging_ready(receiver_sat_state) &&
                receiver_sat_state.time_in_lock > time_in_lock_before_calculating_pvt
                 # Hand PVT the *ranging* signal (the pilot, for a combined spec) as
                 # `system` and the *data* decoder separately: PVT derives the code /

--- a/src/process.jl
+++ b/src/process.jl
@@ -582,7 +582,13 @@ function update_all_receiver_sat_states(receiver_sat_states, track_state, system
                     ),
                     update(
                         receiver_sat_state.carrier_lock_detector,
-                        get_last_fully_integrated_filtered_prompt(
+                        # Every prompt this chunk produced, not just the last one: the
+                        # phase-lock indicator averages over records, and a 4 ms chunk over
+                        # a 1 ms code period completes four of them. Tracking clears this
+                        # buffer at the start of each `track!`, so it holds exactly the
+                        # records of the chunk just processed — and it is the live vector,
+                        # so it must not be retained past this call.
+                        get_filtered_prompts(
                             track_state,
                             group_key,
                             prn,

--- a/src/process.jl
+++ b/src/process.jl
@@ -839,8 +839,11 @@ end
 # ~0.2, 0.8, 1.8, 3.2 s … out of lock — never every frame. The bound matters: an
 # unthrottled full-grid `acquire!` per frame is prohibitively expensive at high
 # sampling rates on churny urban signal. The optimistic lock detector bounds the
-# rate further — a re-detected sat is `is_in_lock` for a ~20-update grace, so
-# `time_out_of_lock` stays 0 and no new attempt fires while it is converging.
+# rate further — a re-detected sat is `is_in_lock` for its detector's warm-up, so
+# `time_out_of_lock` stays 0 and no new attempt fires while it is converging. That
+# grace is 80 primary code periods of the ranging signal, which is 20 updates only
+# on GPS L1 C/A at the default 4 ms chunk; on a 10 ms code it is 200 updates, and
+# in seconds it grows with the code period exactly as the tracking loops do.
 # `reacquire_backoff` sets the base step; `max_reacquire_attempts` caps total
 # attempts before falling back to the periodic full scan (`acquire_every`).
 function should_reacquire(state; reacquire_backoff = 200ms, max_reacquire_attempts = 5)

--- a/src/receive.jl
+++ b/src/receive.jl
@@ -5,8 +5,9 @@ Per-satellite summary emitted for each processed chunk: the estimated carrier-to
 density ratio `cn0`, the latest fully integrated `prompt` correlator value (a scalar
 for single-antenna, an `SVector` for multi-antenna), whether the satellite reports
 itself `is_healthy`, whether its tracking loops are currently closed by the
-vector-tracking navigation filter (`in_vt_loop`; always `false` when VT is disabled), and
-whether those loops have settled enough to range on (`is_ranging_ready`).
+vector-tracking navigation filter (`in_vt_loop`; always `false` when VT is disabled),
+whether those loops have settled enough to range on (`is_ranging_ready`) and whether the
+lock detectors currently declare it locked (`is_in_lock`).
 
 Loop membership is not the same as having determined the solution: a member coasting
 through an obscuration stays `in_vt_loop` and keeps being steered by the filter, but
@@ -18,15 +19,24 @@ and scalar tracking alike — see [`VTStatus`](@ref) for the coasted ones.
 `is_ranging_ready` is what the *receiver* says about its own loops. Both must hold for the
 satellite to contribute to the PVT solution.
 
-Every satellite present in a chunk's `sat_data` is in lock — `remove_lost_satellites` drops
-the others before the payload is built — so there is no separate `is_in_lock` field. What
-`is_ranging_ready` distinguishes is the stage *within* lock: the acquisition → tracking
+What `is_ranging_ready` distinguishes is the stage *within* lock: the acquisition → tracking
 handover is deliberately tolerated (the point is to keep a converging satellite rather than
 drop and reacquire it), so a satellite can be tracked and reported here for some time before
 its code phase is trustworthy enough to range on — from 680 code periods for a healthy
 signal up to 2000 for one whose evidence never comes cleanly. Without this field such a
-satellite is indistinguishable from one the PVT solve is ignoring for no reason. See
-[`is_ranging_ready`](@ref GNSSReceiver.is_ranging_ready) and
+satellite is indistinguishable from one the PVT solve is ignoring for no reason.
+
+`is_in_lock` is the other half of that picture, and it is *not* constant-true here: a
+satellite that loses lock is normally dropped from tracking before the next payload is built
+(`remove_lost_satellites`), but a vector-loop member never is — the navigation filter keeps
+steering it through an outage and decides itself when to release it. Such a member reports
+`in_vt_loop && !is_in_lock`, and `is_ranging_ready` stays latched from before the outage
+(deliberately: the filter kept both its NCOs steered, so it is rangeable the moment the
+signal returns). So `is_ranging_ready` alone does not answer "would the receiver range on
+this satellite right now?" — `collect_pvt_sat_states!` requires both, and a consumer that
+colours or filters on readiness wants both too. See
+[`is_ranging_ready`](@ref GNSSReceiver.is_ranging_ready),
+[`is_in_lock`](@ref GNSSReceiver.is_in_lock) and
 [`LockDwell`](@ref GNSSReceiver.LockDwell).
 """
 struct SatelliteDataOfInterest{P<:Union{<:Complex,<:AbstractVector{<:Complex}}}
@@ -35,40 +45,58 @@ struct SatelliteDataOfInterest{P<:Union{<:Complex,<:AbstractVector{<:Complex}}}
     is_healthy::Bool
     in_vt_loop::Bool
     is_ranging_ready::Bool
+    is_in_lock::Bool
 end
 
 # Back-compat / convenience: a satellite summary built without VT membership defaults to
-# not being in the vector loop, and one built without a readiness flag to being ready. The
-# two defaults point in opposite directions on purpose: absent membership is genuinely "not
-# a member", whereas absent readiness is absent *information*, and reporting it as
-# not-ready would recolour an older caller's display for a satellite it never made any
-# claim about. The receiver itself always fills both in (`build_sat_data`).
+# not being in the vector loop, and one built without a readiness or lock flag to being
+# ready and locked. The defaults point in opposite directions on purpose: absent membership
+# is genuinely "not a member", whereas absent readiness or lock is absent *information*, and
+# reporting either as false would recolour an older caller's display for a satellite it
+# never made any claim about. The receiver itself always fills all three in
+# (`build_sat_data`).
 SatelliteDataOfInterest(
     cn0,
     prompt::P,
     is_healthy,
 ) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
-    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false, true)
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false, true, true)
 SatelliteDataOfInterest{P}(
     cn0,
     prompt,
     is_healthy,
 ) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
-    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false, true)
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false, true, true)
 SatelliteDataOfInterest(
     cn0,
     prompt::P,
     is_healthy,
     in_vt_loop,
 ) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
-    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, true)
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, true, true)
 SatelliteDataOfInterest{P}(
     cn0,
     prompt,
     is_healthy,
     in_vt_loop,
 ) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
-    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, true)
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, true, true)
+SatelliteDataOfInterest(
+    cn0,
+    prompt::P,
+    is_healthy,
+    in_vt_loop,
+    is_ranging_ready,
+) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, is_ranging_ready, true)
+SatelliteDataOfInterest{P}(
+    cn0,
+    prompt,
+    is_healthy,
+    in_vt_loop,
+    is_ranging_ready,
+) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, is_ranging_ready, true)
 
 """
     VTStatus
@@ -166,6 +194,14 @@ is_sat_ranging_ready_at(sat_state_dict, prn) =
 is_sat_in_vt_loop_at(sat_state_dict, prn) =
     haskey(sat_state_dict, prn) && sat_state_dict[prn].in_vt_loop
 
+# Lock verdict of the satellite's detectors, or `false` for one the receiver holds no state
+# for yet — same fail-safe direction again. Constant-true for a scalar-tracked satellite,
+# which is dropped from tracking as soon as it loses lock, but not for a vector-loop member:
+# the navigation filter carries that one through an outage (`remove_lost_satellites`), so the
+# payload has to report the outage rather than imply it away.
+is_sat_in_lock_at(sat_state_dict, prn) =
+    haskey(sat_state_dict, prn) && is_in_lock(sat_state_dict[prn])
+
 # Prompt correlator value of a satellite's ranging signal (the pilot, for a combined
 # system) — the quantity `SatelliteDataOfInterest` reports.
 _ranging_prompt(sat_state) =
@@ -206,6 +242,7 @@ function build_sat_data(receiver_state)
                     is_sat_healthy_at(sat_state_dict, prn),
                     is_sat_in_vt_loop_at(sat_state_dict, prn),
                     is_sat_ranging_ready_at(sat_state_dict, prn),
+                    is_sat_in_lock_at(sat_state_dict, prn),
                 ),
             )
         end

--- a/src/receive.jl
+++ b/src/receive.jl
@@ -4,35 +4,71 @@
 Per-satellite summary emitted for each processed chunk: the estimated carrier-to-noise
 density ratio `cn0`, the latest fully integrated `prompt` correlator value (a scalar
 for single-antenna, an `SVector` for multi-antenna), whether the satellite reports
-itself `is_healthy`, and whether its tracking loops are currently closed by the
-vector-tracking navigation filter (`in_vt_loop`; always `false` when VT is disabled).
+itself `is_healthy`, whether its tracking loops are currently closed by the
+vector-tracking navigation filter (`in_vt_loop`; always `false` when VT is disabled), and
+whether those loops have settled enough to range on (`is_ranging_ready`).
 
 Loop membership is not the same as having determined the solution: a member coasting
 through an obscuration stays `in_vt_loop` and keeps being steered by the filter, but
 withholds its discriminators. Which satellites were *measured* is `pvt.sats`, under vector
 and scalar tracking alike — see [`VTStatus`](@ref) for the coasted ones.
+
+`is_healthy` and `is_ranging_ready` are independent, and neither implies the other:
+`is_healthy` is what the *satellite* says about itself in its navigation message, while
+`is_ranging_ready` is what the *receiver* says about its own loops. Both must hold for the
+satellite to contribute to the PVT solution.
+
+Every satellite present in a chunk's `sat_data` is in lock — `remove_lost_satellites` drops
+the others before the payload is built — so there is no separate `is_in_lock` field. What
+`is_ranging_ready` distinguishes is the stage *within* lock: the acquisition → tracking
+handover is deliberately tolerated (the point is to keep a converging satellite rather than
+drop and reacquire it), so a satellite can be tracked and reported here for some time before
+its code phase is trustworthy enough to range on — from 680 code periods for a healthy
+signal up to 2000 for one whose evidence never comes cleanly. Without this field such a
+satellite is indistinguishable from one the PVT solve is ignoring for no reason. See
+[`is_ranging_ready`](@ref GNSSReceiver.is_ranging_ready) and
+[`LockDwell`](@ref GNSSReceiver.LockDwell).
 """
 struct SatelliteDataOfInterest{P<:Union{<:Complex,<:AbstractVector{<:Complex}}}
     cn0::typeof(1.0dBHz)
     prompt::P
     is_healthy::Bool
     in_vt_loop::Bool
+    is_ranging_ready::Bool
 end
 
 # Back-compat / convenience: a satellite summary built without VT membership defaults to
-# not being in the vector loop.
+# not being in the vector loop, and one built without a readiness flag to being ready. The
+# two defaults point in opposite directions on purpose: absent membership is genuinely "not
+# a member", whereas absent readiness is absent *information*, and reporting it as
+# not-ready would recolour an older caller's display for a satellite it never made any
+# claim about. The receiver itself always fills both in (`build_sat_data`).
 SatelliteDataOfInterest(
     cn0,
     prompt::P,
     is_healthy,
 ) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
-    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false)
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false, true)
 SatelliteDataOfInterest{P}(
     cn0,
     prompt,
     is_healthy,
 ) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
-    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false)
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, false, true)
+SatelliteDataOfInterest(
+    cn0,
+    prompt::P,
+    is_healthy,
+    in_vt_loop,
+) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, true)
+SatelliteDataOfInterest{P}(
+    cn0,
+    prompt,
+    is_healthy,
+    in_vt_loop,
+) where {P<:Union{<:Complex,<:AbstractVector{<:Complex}}} =
+    SatelliteDataOfInterest{P}(cn0, prompt, is_healthy, in_vt_loop, true)
 
 """
     VTStatus
@@ -119,6 +155,12 @@ ReceiverDataOfInterest{S}(
 is_sat_healthy_at(sat_state_dict, prn) =
     haskey(sat_state_dict, prn) && is_sat_healthy(sat_state_dict[prn].decoder)
 
+# Ranging readiness of the satellite's lock detectors, or `false` for one the receiver holds
+# no state for yet — the same fail-safe direction as `is_sat_healthy_at`: absent evidence is
+# never reported as readiness.
+is_sat_ranging_ready_at(sat_state_dict, prn) =
+    haskey(sat_state_dict, prn) && is_ranging_ready(sat_state_dict[prn])
+
 # Whether the satellite is currently in the vector-tracking loop, read from the cached
 # `in_vt_loop` flag on its `ReceiverSatState` (`false` when VT is off or the sat is absent).
 is_sat_in_vt_loop_at(sat_state_dict, prn) =
@@ -163,6 +205,7 @@ function build_sat_data(receiver_state)
                     _ranging_prompt(sat_state),
                     is_sat_healthy_at(sat_state_dict, prn),
                     is_sat_in_vt_loop_at(sat_state_dict, prn),
+                    is_sat_ranging_ready_at(sat_state_dict, prn),
                 ),
             )
         end

--- a/src/vector_tracking.jl
+++ b/src/vector_tracking.jl
@@ -1751,6 +1751,14 @@ function run_vt_iteration(
         receiver_group_states = receiver_sat_states[group_key]
         tracked_sats = get_sat_states(track_state, group_key)
         eligible_prns = vt_eligible_prns(receiver_group_states, keys(tracked_sats))
+        # NOTE: this list is deliberately gated on `is_in_lock` and not on
+        # `is_ranging_ready`, even though admitting a satellite whose code phase is still
+        # tens of metres out into the navigation filter is a real question. It serves two
+        # purposes at once — the membership list handed to `enable_vt!` and the
+        # measurement-eligibility list handed to `collect_vt_members!` below — so gating it
+        # would also withhold discriminators from *existing* members, which is wrong. The
+        # two uses need separating first; the filter meanwhile has its own innovation-based
+        # release.
         prns_in_lock = filter(prn -> is_in_lock(receiver_group_states[prn]), eligible_prns)
         enable_vt!(track_state, group_key, prns_in_lock)
         member_prns = [get_prn(sat) for sat in tracked_sats if in_vt_loop(sat)]

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -303,20 +303,22 @@ end
     @test !occursin("re-acquiring", out)
 end
 
-# The CN0 panel's three bar colours. Every satellite in `sat_data` is in lock, so the colour
-# is what tells a user *why* a locked satellite may still not be in the fix: an unhealthy
-# satellite (its own navigation message) from one whose loops have not settled enough to
-# range on yet (our own tracking, normal right after the handover). Before this distinction
-# existed the latter was indistinguishable from a satellite the PVT solve ignored for no
-# visible reason.
+# The CN0 panel's three bar colours. The colour is what tells a user *why* a tracked
+# satellite may still not be in the fix: an unhealthy satellite (its own navigation message)
+# from one the receiver is not ranging on (our own tracking — normal right after the
+# handover, and also the state of a vector-loop member coasting through an outage). Before
+# this distinction existed the latter was indistinguishable from a satellite the PVT solve
+# ignored for no visible reason.
 @testset "CN0 bar colour separates unhealthy from still-settling" begin
-    sat(; healthy, ranging_ready) = GNSSReceiver.SatelliteDataOfInterest{ComplexF64}(
-        45.0dBHz,
-        complex(1.0, 0.0),
-        healthy,
-        false,
-        ranging_ready,
-    )
+    sat(; healthy, ranging_ready, in_lock = true) =
+        GNSSReceiver.SatelliteDataOfInterest{ComplexF64}(
+            45.0dBHz,
+            complex(1.0, 0.0),
+            healthy,
+            false,
+            ranging_ready,
+            in_lock,
+        )
     color(; kwargs...) = GNSSReceiver.Dashboard._sat_bar_color(sat(; kwargs...))
 
     @test color(; healthy = true, ranging_ready = true) == :green
@@ -326,6 +328,17 @@ end
     @test color(; healthy = false, ranging_ready = true) == :red
     @test color(; healthy = false, ranging_ready = false) == :red
 
+    # A vector-loop member coasting through an obscuration: out of lock, so
+    # `collect_pvt_sat_states!` withholds it from the solve, but healthy and still latched
+    # ranging-ready from before the outage (deliberately — the filter keeps both its NCOs
+    # steered, so it is rangeable the moment the signal returns). Readiness alone would paint
+    # it green, i.e. "healthy and contributing", which is exactly the confusion yellow exists
+    # to remove. Only a vector-loop member reaches this state; a scalar-tracked satellite is
+    # dropped from tracking as soon as it loses lock.
+    @test color(; healthy = true, ranging_ready = true, in_lock = false) == :yellow
+    @test color(; healthy = true, ranging_ready = false, in_lock = false) == :yellow
+    @test color(; healthy = false, ranging_ready = true, in_lock = false) == :red
+
     # All three colours are distinct, so the states are actually distinguishable on screen.
     @test length(
         unique(
@@ -334,13 +347,16 @@ end
         ),
     ) == 3
 
-    # A summary built through the back-compat positional forms reports as ready, so an older
-    # caller's display is coloured exactly as it was before the field existed.
+    # A summary built through the back-compat positional forms reports as ready and locked, so
+    # an older caller's display is coloured exactly as it was before the fields existed.
     @test GNSSReceiver.Dashboard._sat_bar_color(
         GNSSReceiver.SatelliteDataOfInterest(45.0dBHz, complex(1.0, 0.0), true),
     ) == :green
     @test GNSSReceiver.Dashboard._sat_bar_color(
         GNSSReceiver.SatelliteDataOfInterest(45.0dBHz, complex(1.0, 0.0), true, true),
+    ) == :green
+    @test GNSSReceiver.Dashboard._sat_bar_color(
+        GNSSReceiver.SatelliteDataOfInterest(45.0dBHz, complex(1.0, 0.0), true, true, true),
     ) == :green
 end
 

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -303,6 +303,47 @@ end
     @test !occursin("re-acquiring", out)
 end
 
+# The CN0 panel's three bar colours. Every satellite in `sat_data` is in lock, so the colour
+# is what tells a user *why* a locked satellite may still not be in the fix: an unhealthy
+# satellite (its own navigation message) from one whose loops have not settled enough to
+# range on yet (our own tracking, normal right after the handover). Before this distinction
+# existed the latter was indistinguishable from a satellite the PVT solve ignored for no
+# visible reason.
+@testset "CN0 bar colour separates unhealthy from still-settling" begin
+    sat(; healthy, ranging_ready) = GNSSReceiver.SatelliteDataOfInterest{ComplexF64}(
+        45.0dBHz,
+        complex(1.0, 0.0),
+        healthy,
+        false,
+        ranging_ready,
+    )
+    color(; kwargs...) = GNSSReceiver.Dashboard._sat_bar_color(sat(; kwargs...))
+
+    @test color(; healthy = true, ranging_ready = true) == :green
+    @test color(; healthy = true, ranging_ready = false) == :yellow
+    # An unhealthy satellite reads red whatever our loops think of it: it is the worse news,
+    # and it is not something better tracking can fix.
+    @test color(; healthy = false, ranging_ready = true) == :red
+    @test color(; healthy = false, ranging_ready = false) == :red
+
+    # All three colours are distinct, so the states are actually distinguishable on screen.
+    @test length(
+        unique(
+            color(; healthy = h, ranging_ready = r) for
+            (h, r) in ((true, true), (true, false), (false, true))
+        ),
+    ) == 3
+
+    # A summary built through the back-compat positional forms reports as ready, so an older
+    # caller's display is coloured exactly as it was before the field existed.
+    @test GNSSReceiver.Dashboard._sat_bar_color(
+        GNSSReceiver.SatelliteDataOfInterest(45.0dBHz, complex(1.0, 0.0), true),
+    ) == :green
+    @test GNSSReceiver.Dashboard._sat_bar_color(
+        GNSSReceiver.SatelliteDataOfInterest(45.0dBHz, complex(1.0, 0.0), true, true),
+    ) == :green
+end
+
 @testset "GUI with no data" begin
     sat_data_type = GNSSReceiver.SatelliteDataOfInterest{SVector{2,ComplexF64}}
     gui_data = GNSSReceiver.GUIData(

--- a/test/lock_detector.jl
+++ b/test/lock_detector.jl
@@ -64,6 +64,34 @@ end
     @test !GNSSReceiver.is_in_lock(dwell)
 end
 
+@testset "LockDwell's pull-in stage can never be stricter than steady state" begin
+    # The floor is applied in the constructor body, not in the keyword default, so it binds
+    # for a caller that passes the keyword too. Otherwise `pulled_in` latching would *loosen*
+    # the detector: a freshly acquired satellite would be held to the tighter dwell of the two
+    # and a converged one to the looser, which is the staging inverted.
+    inverted = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        out_of_lock_code_periods = 200,
+        pull_in_out_of_lock_code_periods = 50,
+    )
+    @test inverted.pull_in_out_of_lock_time_threshold ≈ 200u"ms"
+    @test GNSSReceiver.current_out_of_lock_time_threshold(inverted) ≈ 200u"ms"
+    # A pull-in allowance above the steady-state dwell is of course kept as given.
+    staged = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        out_of_lock_code_periods = 200,
+        pull_in_out_of_lock_code_periods = 600,
+    )
+    @test staged.pull_in_out_of_lock_time_threshold ≈ 600u"ms"
+    # And the default floor still holds against a steady-state dwell longer than it — the
+    # carrier detector's own 4000 code periods, which leaves it deliberately unstaged.
+    unstaged = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        out_of_lock_code_periods = 4000,
+    )
+    @test unstaged.pull_in_out_of_lock_time_threshold ≈ 4000u"ms"
+end
+
 @testset "LockDwell latches steady state on sustained good evidence" begin
     dwell = GNSSReceiver.LockDwell(;
         reference_integration_time = REFERENCE_T,
@@ -207,9 +235,10 @@ end
     # admits is smaller than the 2-27 m the evidence path already accepts.
     @test healthy.ranging_pull_in_time_threshold ≈ 2 * 1000 * 1u"ms"
 
-    # The backstop is guarded, so a channel that is genuinely failing is dropped by `is_in_lock`
-    # rather than admitted by the timer. A dwell whose clock is over the steady-state threshold
-    # when the timer expires is NOT admitted; it is admitted once the clock is paid back down.
+    # The backstop is guarded on a *zero* out-of-lock clock: what it relaxes is the length of
+    # the clean run, not the requirement that the channel be clean. A dwell with anything left
+    # on the clock is not admitted however long it has run; it is admitted once the debt is
+    # paid off in full — being merely inside what steady state tolerates is not enough.
     guarded = GNSSReceiver.LockDwell(;
         reference_integration_time = REFERENCE_T,
         warm_up_code_periods = 0,
@@ -217,8 +246,9 @@ end
         pull_in_out_of_lock_code_periods = 600,
         pull_in_code_periods = 100,
         # Short enough that the 300 ms of accumulation below happens after the backstop has
-        # expired, which is the situation the guard exists for. `ranging_confirm` has to come
-        # down with it, since the backstop is floored at it.
+        # expired, which is the situation the guard exists for. Both confirm counts have to
+        # come down with it, since the backstop is floored at the larger of them.
+        confirm_code_periods = 100,
         ranging_confirm_code_periods = 100,
         ranging_pull_in_code_periods = 200,
     )
@@ -228,10 +258,35 @@ end
     @test guarded.elapsed >= guarded.ranging_pull_in_time_threshold
     @test guarded.out_of_lock_time > guarded.out_of_lock_time_threshold
     @test !GNSSReceiver.is_ranging_ready(guarded)
-    for _ = 1:30                            # pay it back below the steady threshold
+    for _ = 1:30                            # back under the steady threshold, but not to zero
         guarded = GNSSReceiver.update(guarded, false, 4u"ms")
     end
+    @test guarded.out_of_lock_time < guarded.out_of_lock_time_threshold
+    @test !iszero(guarded.out_of_lock_time)
+    @test !GNSSReceiver.is_ranging_ready(guarded)
+    for _ = 1:45                            # pay off the rest of the debt
+        guarded = GNSSReceiver.update(guarded, false, 4u"ms")
+    end
+    @test iszero(guarded.out_of_lock_time)
     @test GNSSReceiver.is_ranging_ready(guarded)
+
+    # The guard has to be *reachable*, which is what makes it a health test rather than
+    # decoration. A tolerance guard is not: the clock can never exceed
+    # `elapsed - warm_up_time_threshold`, so wherever the dwell outlasts the backstop it
+    # cannot fail before the timer fires. That is the carrier detector's own configuration —
+    # a 4000-code-period dwell against a 2000-period backstop — and a channel whose
+    # phase-lock indicator never once passes must not be admitted to ranging there.
+    never_passing = GNSSReceiver.CarrierLockDetector(;
+        reference_integration_time = REFERENCE_T,
+    )
+    @test never_passing.dwell.out_of_lock_time_threshold >
+          never_passing.dwell.ranging_pull_in_time_threshold
+    for _ = 1:1200                          # 4.8 s: well past both the backstop and the dwell
+        # Pure quadrature, so the indicator sits at -1.0 — out of lock on every chunk.
+        never_passing = GNSSReceiver.update(never_passing, complex(0.1, 10.0), 4u"ms")
+        @test !GNSSReceiver.is_ranging_ready(never_passing)
+    end
+    @test !GNSSReceiver.is_in_lock(never_passing)   # dropped by the dwell, as it should be
 
     # Sustained failure is never admitted: pure out-of-lock evidence loses lock and stays out.
     failing = GNSSReceiver.LockDwell(;
@@ -247,16 +302,18 @@ end
     # `is_ranging_ready ⟹ has_pulled_in` holds structurally, not by the thresholds happening to
     # be ordered: the timer path takes the freshly computed `pulled_in` as a conjunct, so even a
     # backstop configured to expire before the pull-in timer cannot admit ranging first.
+    # Both confirm counts are 100 code periods against runs that never get past one chunk, so
+    # neither evidence path can fire: `pulled_in` can only be promoted by its timer at 800 code
+    # periods, and ranging only by its backstop, which the flooring leaves at 100.
     perverse = GNSSReceiver.LockDwell(;
         reference_integration_time = REFERENCE_T,
         warm_up_code_periods = 0,
-        confirm_code_periods = 10_000,       # `pulled_in`'s evidence path can never fire, so
-        pull_in_code_periods = 800,          # only its timer, at 800 code periods, can promote
-        ranging_confirm_code_periods = 100,  # and ranging's evidence path never fires either,
-        ranging_pull_in_code_periods = 100,  # so only its backstop, at 100, can admit
+        confirm_code_periods = 100,
+        pull_in_code_periods = 800,
+        ranging_confirm_code_periods = 100,
+        ranging_pull_in_code_periods = 100,
     )
-    # Alternating evidence never builds a 100-code-period run, so neither evidence path can fire
-    # here; the backstop is 700 code periods early, and must still wait for `pulled_in`.
+    # The backstop is 700 code periods early, and must still wait for `pulled_in`.
     longest_run = 0u"ms"
     for i = 1:400
         perverse = GNSSReceiver.update(perverse, isodd(i), 4u"ms")
@@ -276,6 +333,19 @@ end
     )
     @test floored_backstop.ranging_pull_in_time_threshold >=
           floored_backstop.ranging_confirm_time_threshold
+
+    # Floored against the *effective* evidence bar, not the raw keyword: `confirm_code_periods`
+    # can be what raised it, and a backstop ordered only against the raw value would then
+    # expire before the evidence path could possibly fire — the very case the floor exists for.
+    transitively_floored = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        confirm_code_periods = 500,
+        ranging_confirm_code_periods = 100,
+        ranging_pull_in_code_periods = 300,
+    )
+    @test transitively_floored.ranging_confirm_time_threshold ≈ 500u"ms"
+    @test transitively_floored.ranging_pull_in_time_threshold >=
+          transitively_floored.ranging_confirm_time_threshold
 
     # The backstop must not touch the dwell: a fade after a successful handover is still noticed
     # on the steady-state timescale (200 code periods), which is the whole reason the two latches

--- a/test/lock_detector.jl
+++ b/test/lock_detector.jl
@@ -15,7 +15,6 @@ const REFERENCE_T = 1u"ms"
         carrier = GNSSReceiver.CarrierLockDetector(; reference_integration_time = code_period)
         @test carrier.out_of_lock_time_threshold ≈ factor * 4u"s"
         @test carrier.wait_time_threshold ≈ factor * 80u"ms"
-        @test carrier.integration_time_threshold ≈ factor * 80u"ms"
     end
 
     # On GPS L1 C/A the defaults reproduce the historical absolute timings exactly, so the
@@ -36,14 +35,14 @@ const REFERENCE_T = 1u"ms"
     ).out_of_lock_time_threshold ≈ 800u"ms"
     @test GNSSReceiver.CarrierLockDetector(;
         reference_integration_time = in_inverse_hz,
-    ).integration_time_threshold ≈ 320u"ms"
+    ).wait_time_threshold ≈ 320u"ms"
 
     # A count that cannot describe a timing is rejected rather than silently scaled into a
     # negative threshold, which would read as "out of lock" from the very first update.
     @test_throws ArgumentError GNSSReceiver.CodeLockDetector(; out_of_lock_code_periods = 0)
     @test_throws ArgumentError GNSSReceiver.CodeLockDetector(; warm_up_code_periods = -1)
     @test_throws ArgumentError GNSSReceiver.CarrierLockDetector(;
-        integration_code_periods = NaN,
+        out_of_lock_code_periods = NaN,
     )
     @test_throws ArgumentError GNSSReceiver.CodeLockDetector(;
         reference_integration_time = 0u"ms",
@@ -542,27 +541,288 @@ end
     @test on_twenty_blocks.out_of_lock_time == 0u"s"
 end
 
-@testset "CarrierLockDetector accumulates out-of-lock on weak in-phase power" begin
-    detector = GNSSReceiver.CarrierLockDetector(;
-        reference_integration_time = REFERENCE_T,
-        out_of_lock_code_periods = 200,
-        warm_up_code_periods = 80,
-        integration_code_periods = 80,
-    )
-    # A prompt dominated by its quadrature component fails the in-phase dominance
-    # test each integration block, so out-of-lock time accumulates and lock is lost.
+# ---------------------------------------------------------------------------------------
+# CarrierLockDetector — the Van Dierendonck NBD/NBP phase-lock indicator
+# ---------------------------------------------------------------------------------------
+
+carrier_detector(; kwargs...) =
+    GNSSReceiver.CarrierLockDetector(; reference_integration_time = REFERENCE_T, kwargs...)
+
+# Prompts at a known post-integration SNR and carrier phase error, matching the model the
+# detector is derived against: a constant signal amplitude `√ρ` in unit-total-variance
+# complex Gaussian noise.
+function synthetic_prompts(snr, phase_error_deg, count, seed)
+    rng = Random.Xoshiro(seed)
+    amplitude = sqrt(snr)
+    [amplitude * cis(deg2rad(phase_error_deg)) + randn(rng, ComplexF64) for _ = 1:count]
+end
+
+# Hand-rolled rather than pulling `Statistics` into the test target for three one-liners.
+# `spread_of` is the population RMS about the mean, the same pattern
+# `ion_rtlsdr_integration.jl` uses for residual scatter; `percentile_of` is the nearest-rank
+# percentile, since the interpolation `Statistics.quantile` adds is irrelevant to a
+# threshold comparison.
+mean_of(x) = sum(x) / length(x)
+spread_of(x) = sqrt(sum(abs2, x .- mean_of(x)) / length(x))
+percentile_of(x, q) = sort(x)[clamp(ceil(Int, q * length(x)), 1, length(x))]
+
+@testset "CarrierLockDetector's indicator matches cos(2φ)·ρ/(ρ+1)" begin
+    # The statistic's whole justification is this expectation. Drive the real detector with
+    # prompts at known SNR and phase error and check it converges to the analytic value.
+    for snr in (1.0, 3.162, 10.0), phase in (0.0, 15.0, 30.0, 45.0)
+        detector = carrier_detector(; smoothing_records = 2000)
+        detector =
+            GNSSReceiver.update(detector, synthetic_prompts(snr, phase, 40000, 42), 40u"s")
+        expected = cosd(2 * phase) * snr / (snr + 1)
+        @test GNSSReceiver.phase_lock_indicator(detector) ≈ expected atol = 0.02
+    end
+end
+
+@testset "CarrierLockDetector's indicator is unbiased on noise" begin
+    # `E[PLI] = cos(2φ)·ρ/(ρ+1)` goes to zero as the signal power does, so a dead channel
+    # sits at zero and the distance from there to the threshold is a real detection margin
+    # that can be quoted (median 0.015, p99 0.14 at a 200-record window).
+    indicators = map(1:40) do seed
+        detector = carrier_detector(; smoothing_records = 200)
+        detector =
+            GNSSReceiver.update(detector, synthetic_prompts(0.0, 0.0, 4000, seed), 4u"s")
+        GNSSReceiver.phase_lock_indicator(detector)
+    end
+    @test abs(mean_of(indicators)) < 0.05
+    # And it stays clear of the default threshold, so noise alone does not hold lock.
+    @test maximum(indicators) < 0.25
+end
+
+@testset "CarrierLockDetector rejects a quadrature-dominated prompt" begin
+    detector = carrier_detector()
+    # A prompt dominated by its quadrature component is 90° off: cos(2φ) = −1.
     weak_inphase = complex(0.1, 10.0)
-    for _ = 1:80
+    for _ = 1:200
         detector = GNSSReceiver.update(detector, weak_inphase, 4u"ms")
     end
+    @test GNSSReceiver.phase_lock_indicator(detector) < 0
+    @test GNSSReceiver.is_below_phase_lock_threshold(detector)
     @test detector.out_of_lock_time > 0u"s"
+
+    # Sustained, it loses lock once the 4 s dwell is exhausted.
+    for _ = 1:1000
+        detector = GNSSReceiver.update(detector, weak_inphase, 4u"ms")
+    end
     @test !GNSSReceiver.is_in_lock(detector)
 
-    # A prompt dominated by its in-phase component resets the accumulated time.
+    # Recovery. The indicator is a smoothed quantity, so swinging it from cos(2φ) = −1 back
+    # over the threshold takes on the order of one `smoothing_records` window (200 prompts
+    # by default) — a single good prompt cannot and should not do it. That is the deliberate
+    # asymmetry: the detector decides quickly and changes its mind slowly.
     strong_inphase = complex(10.0, 0.1)
-    for _ = 1:40
+    detector = GNSSReceiver.update(detector, strong_inphase, 4u"ms")
+    @test GNSSReceiver.is_below_phase_lock_threshold(detector)
+
+    for _ = 1:250
         detector = GNSSReceiver.update(detector, strong_inphase, 4u"ms")
     end
+    @test GNSSReceiver.phase_lock_indicator(detector) > 0.25
+    # Once the indicator is back above threshold the accumulated time clears outright —
+    # the "optimistic" credit, so a *consecutive* run of failures is needed to declare loss.
     @test detector.out_of_lock_time == 0u"s"
     @test GNSSReceiver.is_in_lock(detector)
+end
+
+@testset "CarrierLockDetector needs a consecutive run of failures" begin
+    # Intermittent dips must not accumulate: a marginal satellite's indicator crosses the
+    # threshold in both directions, and a paying-back accumulator would random-walk into a
+    # spurious loss.
+    detector = carrier_detector(; smoothing_records = 1)
+    for i = 1:2000
+        prompt = isodd(i) ? complex(10.0, 0.1) : complex(0.1, 10.0)
+        detector = GNSSReceiver.update(detector, prompt, 4u"ms")
+    end
+    @test GNSSReceiver.is_in_lock(detector)
+    @test detector.out_of_lock_time <= 4.001u"ms"
+end
+
+@testset "CarrierLockDetector uses every prompt of the chunk" begin
+    # `process` hands the detector the chunk's whole prompt sequence. Folding four prompts
+    # in one update must advance the moving averages exactly as four single-prompt updates
+    # would — otherwise the smoothing window would silently depend on the chunk length.
+    prompts = synthetic_prompts(10.0, 20.0, 4, 7)
+    batched = GNSSReceiver.update(carrier_detector(), prompts, 4u"ms")
+    one_by_one = carrier_detector()
+    for prompt in prompts
+        one_by_one = GNSSReceiver.update(one_by_one, prompt, 1u"ms")
+    end
+    @test GNSSReceiver.phase_lock_indicator(batched) ≈
+          GNSSReceiver.phase_lock_indicator(one_by_one)
+
+    # Reading only the last prompt of each chunk — what the receiver used to do — throws
+    # three quarters of the evidence away, so the indicator is measurably noisier.
+    spread(step) = spread_of(
+        map(1:60) do seed
+            detector = carrier_detector(; smoothing_records = 200)
+            all_prompts = synthetic_prompts(1.0, 0.0, 800, seed)
+            for i = 1:step:length(all_prompts)
+                detector = GNSSReceiver.update(detector, all_prompts[i], 4u"ms")
+            end
+            GNSSReceiver.phase_lock_indicator(detector)
+        end,
+    )
+    @test spread(1) < spread(4)
+end
+
+@testset "CarrierLockDetector leaves the code detector as the binding limit" begin
+    # The indicator saturates at ρ/(ρ+1), so the threshold has to be read together with the
+    # C/N0 one. At the code-lock threshold (30 dBHz over a 1 ms record, ρ = 1) even perfect
+    # phase lock reads only 0.5, so the carrier threshold must sit below that or it would
+    # reject satellites the code detector accepts.
+    detector = carrier_detector()
+    @test detector.phase_lock_threshold < 0.5
+
+    # A perfectly phase-locked signal exactly at the code-lock threshold must pass.
+    at_code_threshold = carrier_detector(; smoothing_records = 2000)
+    at_code_threshold = GNSSReceiver.update(
+        at_code_threshold,
+        synthetic_prompts(1.0, 0.0, 40000, 3),
+        40u"s",
+    )
+    @test !GNSSReceiver.is_below_phase_lock_threshold(at_code_threshold)
+
+    # Read as a phase test at that SNR, the default demands |φ| ≤ 30°.
+    @test cosd(2 * 30.0) * 1.0 / (1.0 + 1.0) ≈ 0.25
+    # Read as a pure sensitivity floor it is ρ ≥ 1/3 — 25.2 dBHz at a 1 ms record, i.e.
+    # below the code detector's 30 dBHz, so the code detector stays the binding limit.
+    floor_snr = detector.phase_lock_threshold / (1 - detector.phase_lock_threshold)
+    @test floor_snr ≈ 1 / 3
+    @test 10 * log10(floor_snr / 1e-3) < 30
+end
+
+@testset "CarrierLockDetector treats an unmeasured or non-finite indicator safely" begin
+    # Before any prompt has been folded in there is nothing to decide on; the warm-up owns
+    # that window, so the detector must not report itself out of lock.
+    fresh = carrier_detector()
+    @test isnan(GNSSReceiver.phase_lock_indicator(fresh))
+    @test !GNSSReceiver.is_below_phase_lock_threshold(fresh)
+    @test GNSSReceiver.is_in_lock(fresh)
+
+    # An all-zero prompt (a dead correlator channel) leaves the total power at zero, so the
+    # indicator stays unmeasured rather than becoming a NaN that holds lock forever.
+    dead = GNSSReceiver.update(fresh, complex(0.0, 0.0), 4u"ms")
+    @test GNSSReceiver.is_in_lock(dead)
+    # A NaN prompt must count as out of lock: it poisons both averages permanently, and
+    # `NaN > 0` is `false`, so it would otherwise read as "nothing measured yet" forever.
+    nan_fed = GNSSReceiver.update(fresh, complex(NaN, NaN), 4u"ms")
+    @test GNSSReceiver.is_below_phase_lock_threshold(nan_fed)
+
+    # An empty prompt sequence (no record completed this chunk) still advances the timers
+    # without inventing evidence.
+    empty_chunk = GNSSReceiver.update(fresh, ComplexF64[], 4u"ms")
+    @test empty_chunk.wait_time ≈ 4u"ms"
+    @test isnan(GNSSReceiver.phase_lock_indicator(empty_chunk))
+    @test GNSSReceiver.is_in_lock(empty_chunk)
+end
+
+@testset "CarrierLockDetector's smoothing window is counted in records" begin
+    # The gain is applied once per prompt, and a prompt is one record spanning
+    # `get_last_fully_integrated_num_code_blocks` code blocks — so this window is NOT a
+    # count of code periods, unlike the detector's two timings (those are driven by
+    # `signal_duration`, which is real elapsed time). They coincide only while Tracking's
+    # `preferred_num_code_blocks_to_integrate` stays at 1. The name has to say which it is.
+    @test carrier_detector(; smoothing_records = 200).smoothing_gain ≈ 1 / 200
+    # Folding N prompts advances the average by N gain steps regardless of the
+    # `signal_duration` the chunk claims — which is exactly why the window cannot be
+    # expressed in code periods.
+    prompts = synthetic_prompts(10.0, 0.0, 50, 11)
+    over_one_chunk = GNSSReceiver.update(carrier_detector(), prompts, 4u"ms")
+    over_fifty_chunks = carrier_detector()
+    for prompt in prompts
+        over_fifty_chunks = GNSSReceiver.update(over_fifty_chunks, prompt, 40u"ms")
+    end
+    @test GNSSReceiver.phase_lock_indicator(over_one_chunk) ≈
+          GNSSReceiver.phase_lock_indicator(over_fifty_chunks)
+    # 50 chunks of 40 ms against one of 4 ms: 500× the signal time, the same 50 gain steps.
+    # The timers, driven by `signal_duration`, do see the difference — the second detector
+    # has run its warm-up out while the first has barely started it.
+    @test over_one_chunk.wait_time ≈ 4u"ms"
+    @test over_fifty_chunks.wait_time ≈ over_fifty_chunks.wait_time_threshold
+end
+
+@testset "CarrierLockDetector rejects a configuration that would silently kill the channel" begin
+    # `smoothing_records = 0` gives an infinite gain, so both moving averages become `NaN`
+    # on the first prompt; `is_below_phase_lock_threshold` then reads that as a dead
+    # correlator and holds the channel permanently out of lock. A window below one record
+    # gives a gain above 1, which makes the average overshoot every sample instead of
+    # smoothing it. Neither is detectable downstream, so both have to fail at construction.
+    @test isnan(
+        GNSSReceiver.phase_lock_indicator(
+            GNSSReceiver.update(
+                GNSSReceiver.CarrierLockDetector(
+                    0.0,
+                    0.0,
+                    Inf,
+                    0.25,
+                    0.0u"s",
+                    4u"s",
+                    80u"ms",
+                    80u"ms",
+                ),
+                complex(1.0, 0.0),
+                4u"ms",
+            ),
+        ),
+    )
+    @test_throws ArgumentError carrier_detector(; smoothing_records = 0)
+    @test_throws ArgumentError carrier_detector(; smoothing_records = -200)
+    @test_throws ArgumentError carrier_detector(; smoothing_records = 0.5)
+    @test_throws ArgumentError carrier_detector(; smoothing_records = NaN)
+    @test_throws ArgumentError carrier_detector(; smoothing_records = Inf)
+    @test carrier_detector(; smoothing_records = 1).smoothing_gain == 1.0
+
+    # The indicator is `cos(2φ)·ρ/(ρ+1) ∈ [-1, 1]`, so a threshold at or above 1 is
+    # unreachable at any C/N0 (permanently out of lock) and one at or below −1 is met by
+    # anything (loss never reported). The practical ceiling is lower — the indicator
+    # saturates at ρ/(ρ+1) = 0.5 at the 30 dBHz the code detector accepts over a one-block
+    # record — but that bound moves with the record length, so only the mathematical one is
+    # enforced.
+    @test_throws ArgumentError carrier_detector(; phase_lock_threshold = 1.0)
+    @test_throws ArgumentError carrier_detector(; phase_lock_threshold = 1.5)
+    @test_throws ArgumentError carrier_detector(; phase_lock_threshold = -1.0)
+    @test_throws ArgumentError carrier_detector(; phase_lock_threshold = NaN)
+    @test carrier_detector(; phase_lock_threshold = 0.9) isa GNSSReceiver.CarrierLockDetector
+end
+
+@testset "CarrierLockDetector's quoted noise figures are asymptotic" begin
+    # The 80-code-period warm-up is shorter than the 200-record smoothing window, so the
+    # first judgement is made on an average that has not converged and the docstring's
+    # noise-only figures do not yet apply. Measured here so the docstring's claim is checked
+    # rather than asserted: the p99 falls monotonically as the window fills, and at the
+    # warm-up boundary it is still above the 0.25 threshold.
+    noise_indicators(nprompts) = map(1:2000) do seed
+        detector = carrier_detector(; smoothing_records = 200)
+        GNSSReceiver.phase_lock_indicator(
+            GNSSReceiver.update(
+                detector,
+                synthetic_prompts(0.0, 0.0, nprompts, seed),
+                4u"ms",
+            ),
+        )
+    end
+    p99(nprompts) = percentile_of(noise_indicators(nprompts), 0.99)
+    early, window, converged = p99(80), p99(200), p99(2000)
+    @test early > 0.25          # above threshold ~1% of the time when the warm-up ends
+    @test window < early        # and the spread shrinks as the average fills
+    @test converged < window
+    @test converged < 0.15      # the asymptotic figure the docstring quotes
+
+    # The warm-up is deliberately not lengthened to the window: clearing the dwell on any
+    # favourable chunk, together with the 4000-code-period dwell, means loss needs a
+    # *consecutive* run of failures, so an early excursion in either direction is absorbed.
+    @test carrier_detector().wait_time_threshold ≈ 80u"ms"
+    # In the false-drop direction the early window is already tight enough: at the code-lock
+    # threshold (ρ = 1, perfect phase lock) the indicator is essentially never below 0.25.
+    at_threshold = map(1:1000) do seed
+        detector = carrier_detector(; smoothing_records = 200)
+        GNSSReceiver.phase_lock_indicator(
+            GNSSReceiver.update(detector, synthetic_prompts(1.0, 0.0, 80, seed), 4u"ms"),
+        )
+    end
+    @test count(<(0.25), at_threshold) / length(at_threshold) < 0.01
 end

--- a/test/lock_detector.jl
+++ b/test/lock_detector.jl
@@ -2,14 +2,62 @@
 # to, so a record of this length is credited exactly `cn0_threshold` (no relaxation).
 const REFERENCE_T = 1u"ms"
 
+@testset "Detector timings scale with the primary code period" begin
+    # This is the headline fix: the same code-period counts must become proportionally
+    # longer absolute times on a longer code, because Tracking's loop bandwidths are
+    # `0.018 / T_code` and so every loop time constant scales with `T_code`.
+    for (code_period, factor) in ((1u"ms", 1), (4u"ms", 4), (10u"ms", 10))
+        code = GNSSReceiver.CodeLockDetector(; reference_integration_time = code_period)
+        @test code.reference_integration_time ≈ code_period
+        @test code.out_of_lock_time_threshold ≈ factor * 200u"ms"
+        @test code.wait_time_threshold ≈ factor * 80u"ms"
+
+        carrier = GNSSReceiver.CarrierLockDetector(; reference_integration_time = code_period)
+        @test carrier.out_of_lock_time_threshold ≈ factor * 4u"s"
+        @test carrier.wait_time_threshold ≈ factor * 80u"ms"
+        @test carrier.integration_time_threshold ≈ factor * 80u"ms"
+    end
+
+    # On GPS L1 C/A the defaults reproduce the historical absolute timings exactly, so the
+    # signal the receiver was tuned against sees no change at all.
+    l1ca = GNSSReceiver.primary_code_period(GPSL1CA())
+    @test GNSSReceiver.CodeLockDetector(;
+        reference_integration_time = l1ca,
+    ).out_of_lock_time_threshold ≈ 200u"ms"
+    @test GNSSReceiver.CarrierLockDetector(;
+        reference_integration_time = l1ca,
+    ).out_of_lock_time_threshold ≈ 4u"s"
+
+    # Tracking reports integration times in `Hz^-1`; that must configure identically, so the
+    # constructors have to `uconvert` rather than assume seconds.
+    in_inverse_hz = uconvert(u"Hz^-1", 4u"ms")
+    @test GNSSReceiver.CodeLockDetector(;
+        reference_integration_time = in_inverse_hz,
+    ).out_of_lock_time_threshold ≈ 800u"ms"
+    @test GNSSReceiver.CarrierLockDetector(;
+        reference_integration_time = in_inverse_hz,
+    ).integration_time_threshold ≈ 320u"ms"
+
+    # A count that cannot describe a timing is rejected rather than silently scaled into a
+    # negative threshold, which would read as "out of lock" from the very first update.
+    @test_throws ArgumentError GNSSReceiver.CodeLockDetector(; out_of_lock_code_periods = 0)
+    @test_throws ArgumentError GNSSReceiver.CodeLockDetector(; warm_up_code_periods = -1)
+    @test_throws ArgumentError GNSSReceiver.CarrierLockDetector(;
+        integration_code_periods = NaN,
+    )
+    @test_throws ArgumentError GNSSReceiver.CodeLockDetector(;
+        reference_integration_time = 0u"ms",
+    )
+end
+
 @testset "CodeLockDetector accumulates and pays back out-of-lock time" begin
     # Warm up past the wait-time threshold with a healthy CN0 so the detector
     # starts arming its out-of-lock timer.
     detector = GNSSReceiver.CodeLockDetector(;
         cn0_threshold = 30u"dBHz",
         reference_integration_time = REFERENCE_T,
-        out_of_lock_time_threshold = 200u"ms",
-        wait_time_threshold = 80u"ms",
+        out_of_lock_code_periods = 200,
+        warm_up_code_periods = 80,
     )
     for _ = 1:20
         detector = GNSSReceiver.update(detector, 45u"dBHz", REFERENCE_T, 4u"ms")
@@ -38,8 +86,8 @@ end
     detector = GNSSReceiver.CodeLockDetector(;
         cn0_threshold = 30u"dBHz",
         reference_integration_time = REFERENCE_T,
-        out_of_lock_time_threshold = 200u"ms",
-        wait_time_threshold = 80u"ms",
+        out_of_lock_code_periods = 200,
+        warm_up_code_periods = 80,
     )
     for _ = 1:20
         detector = GNSSReceiver.update(detector, 45u"dBHz", REFERENCE_T, 4u"ms")
@@ -62,12 +110,12 @@ end
 end
 
 @testset "CodeLockDetector stays neutral before the wait time elapses" begin
-    # Before `wait_time_threshold` is reached a bad CN0 must not accumulate any
+    # Before the warm-up elapses a bad CN0 must not accumulate any
     # out-of-lock time (the detector is still warming up).
     detector = GNSSReceiver.CodeLockDetector(;
         cn0_threshold = 30u"dBHz",
         reference_integration_time = REFERENCE_T,
-        wait_time_threshold = 80u"ms",
+        warm_up_code_periods = 80,
     )
     detector = GNSSReceiver.update(detector, 5u"dBHz", REFERENCE_T, 4u"ms")
     @test detector.out_of_lock_time == 0u"s"
@@ -145,6 +193,23 @@ end
     state = GNSSReceiver.ReceiverSatState(GPSL1CA(), 1)
     @test state.code_lock_detector.reference_integration_time ==
           GNSSReceiver.primary_code_period(GPSL1CA())
+    # Both detectors must be anchored, not just the code one.
+    @test state.code_lock_detector.out_of_lock_time_threshold ≈ 200u"ms"
+    @test state.carrier_lock_detector.out_of_lock_time_threshold ≈ 4u"s"
+
+    # Galileo E1B's 4 ms code period gives timings 4× longer, matching its 4× slower loops —
+    # the property whose absence made lock detection fail on the slower signals. Built from
+    # the code period directly rather than through `ReceiverSatState(GalileoE1B(), 1)`: that
+    # would construct a `GNSSDecoderState`, pulling in Galileo's FEC decoder (Aff3ct), whose
+    # binary does not load on Windows. The `ReceiverSatState` wiring is already covered by
+    # the GPS L1 C/A case above; what is E1B-specific here is only the code period.
+    e1b_period = GNSSReceiver.primary_code_period(GalileoE1B())
+    @test GNSSReceiver.CodeLockDetector(;
+        reference_integration_time = e1b_period,
+    ).out_of_lock_time_threshold ≈ 800u"ms"
+    @test GNSSReceiver.CarrierLockDetector(;
+        reference_integration_time = e1b_period,
+    ).out_of_lock_time_threshold ≈ 16u"s"
 end
 
 # ---------------------------------------------------------------------------------------
@@ -425,7 +490,7 @@ end
 
     # The consequence end to end: the out-of-lock dwell is spent monotonically instead of
     # being paid back on the realizations the moment ratio let through, so lock is lost in
-    # exactly `wait_time_threshold + out_of_lock_time_threshold` of signal — 20 + 50 updates
+    # exactly the warm-up plus the out-of-lock dwell — 20 + 50 updates
     # of 4 ms — rather than the ~85 the moment ratio needs.
     duration = 4u"ms"
     for num_updates in (69, 70)
@@ -479,9 +544,10 @@ end
 
 @testset "CarrierLockDetector accumulates out-of-lock on weak in-phase power" begin
     detector = GNSSReceiver.CarrierLockDetector(;
-        out_of_lock_time_threshold = 200u"ms",
-        wait_time_threshold = 80u"ms",
-        integration_time_threshold = 80u"ms",
+        reference_integration_time = REFERENCE_T,
+        out_of_lock_code_periods = 200,
+        warm_up_code_periods = 80,
+        integration_code_periods = 80,
     )
     # A prompt dominated by its quadrature component fails the in-phase dominance
     # test each integration block, so out-of-lock time accumulates and lock is lost.

--- a/test/lock_detector.jl
+++ b/test/lock_detector.jl
@@ -2,6 +2,419 @@
 # to, so a record of this length is credited exactly `cn0_threshold` (no relaxation).
 const REFERENCE_T = 1u"ms"
 
+# The absolute timings this receiver used before the detectors were scaled to the code period,
+# reproduced by passing the equivalent code-period counts — so a test can assert that the old
+# configuration fails where the new one holds.
+old_absolute_code_kwargs(code_period) = (
+    warm_up_code_periods = round(Int, ustrip(u"s", 80u"ms") / ustrip(u"s", code_period)),
+    out_of_lock_code_periods = round(Int, ustrip(u"s", 200u"ms") / ustrip(u"s", code_period)),
+    # A single unstaged dwell: no pull-in credit at all.
+    pull_in_code_periods = 0,
+    confirm_code_periods = 0,
+    pull_in_out_of_lock_code_periods =
+        round(Int, ustrip(u"s", 200u"ms") / ustrip(u"s", code_period)),
+)
+
+# ---------------------------------------------------------------------------------------
+# LockDwell — the staging shared by both detectors
+# ---------------------------------------------------------------------------------------
+
+@testset "LockDwell accumulates nothing during the warm-up" begin
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 80,
+    )
+    for _ = 1:20
+        dwell = GNSSReceiver.update(dwell, true, 4u"ms")
+    end
+    # Exactly 80 ms of signal has passed, all of it warm-up.
+    @test dwell.elapsed ≈ 80u"ms"
+    @test dwell.out_of_lock_time == 0u"s"
+    @test GNSSReceiver.is_in_lock(dwell)
+
+    # The very next chunk is past the warm-up and does count.
+    dwell = GNSSReceiver.update(dwell, true, 4u"ms")
+    @test dwell.out_of_lock_time ≈ 4u"ms"
+end
+
+@testset "LockDwell tolerates more while pulling in than in steady state" begin
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        out_of_lock_code_periods = 200,
+        pull_in_out_of_lock_code_periods = 600,
+        pull_in_code_periods = 800,
+    )
+    @test !dwell.pulled_in
+    # 400 ms of continuous out-of-lock evidence — twice the steady-state threshold — is
+    # still tolerated, because the handover has not finished.
+    for _ = 1:100
+        dwell = GNSSReceiver.update(dwell, true, 4u"ms")
+    end
+    @test dwell.out_of_lock_time ≈ 400u"ms"
+    @test !dwell.pulled_in
+    @test GNSSReceiver.is_in_lock(dwell)
+    @test GNSSReceiver.current_out_of_lock_time_threshold(dwell) ≈ 600u"ms"
+
+    # Past the pull-in threshold it is lost: 600 ms accumulated.
+    for _ = 1:50
+        dwell = GNSSReceiver.update(dwell, true, 4u"ms")
+    end
+    @test dwell.out_of_lock_time >= 600u"ms"
+    @test !GNSSReceiver.is_in_lock(dwell)
+end
+
+@testset "LockDwell latches steady state on sustained good evidence" begin
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        confirm_code_periods = 200,
+        pull_in_code_periods = 800,
+    )
+    # 196 ms of clean evidence is not yet a confirmation.
+    for _ = 1:49
+        dwell = GNSSReceiver.update(dwell, false, 4u"ms")
+    end
+    @test !dwell.pulled_in
+    @test dwell.settled_time ≈ 196u"ms"
+
+    # 200 ms is, and it latches well before `pull_in_time_threshold` (800 ms) expires.
+    dwell = GNSSReceiver.update(dwell, false, 4u"ms")
+    @test dwell.pulled_in
+    @test dwell.elapsed ≈ 200u"ms"
+    @test GNSSReceiver.current_out_of_lock_time_threshold(dwell) ≈ 200u"ms"
+
+    # And it never goes back: a later bad patch keeps the tighter steady threshold, which
+    # is what makes a fade after a successful handover detected on the steady timescale.
+    for _ = 1:10
+        dwell = GNSSReceiver.update(dwell, true, 4u"ms")
+    end
+    @test dwell.pulled_in
+    @test dwell.settled_time == 0u"s"
+end
+
+@testset "Ranging readiness is a separate, later latch than the dwell stage" begin
+    # The two questions have different natural timescales and one threshold cannot serve both.
+    # `pulled_in` may fire as soon as the C/N0 deficit clears, so a fade is caught on the
+    # steady-state timescale; ranging must wait for the CODE LOOP, which is far slower. On BPSK
+    # the prompt only loses `1 − |Δτ|`, so a GPS L1 C/A satellite looks healthy almost at once
+    # while its DLL (`1/B_L` = 1000 code periods) is still walking the handover error in:
+    # measured residual code phase after 200 code periods of clean evidence is 0.09-0.19 chip
+    # (26-54 m of pseudorange error), versus 0.007-0.09 chip (2-27 m) after 600.
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = GNSSReceiver.primary_code_period(GPSL1CA()),
+    )
+    @test dwell.ranging_confirm_time_threshold > dwell.confirm_time_threshold
+    @test dwell.ranging_confirm_time_threshold >= 0.5u"s"   # ≥ half a DLL time constant
+    # Still free against `receive`'s own 2 s `time_in_lock_before_calculating_pvt` gate on
+    # GPS L1 C/A, so being conservative costs no time to first fix.
+    @test dwell.warm_up_time_threshold + dwell.ranging_confirm_time_threshold < 2u"s"
+    # Ranging can never be ready before the handover is declared over, however it is configured.
+    floored = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        confirm_code_periods = 500,
+        ranging_confirm_code_periods = 100,
+    )
+    @test floored.ranging_confirm_time_threshold >= floored.confirm_time_threshold
+
+    # Driven end to end: the dwell tightens first, ranging follows later.
+    d = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        confirm_code_periods = 200,
+        ranging_confirm_code_periods = 600,
+    )
+    for _ = 1:50
+        d = GNSSReceiver.update(d, false, 4u"ms")
+    end
+    @test GNSSReceiver.has_pulled_in(d)          # dwell tightened at 200 code periods
+    @test !GNSSReceiver.is_ranging_ready(d)      # but not yet trustworthy to range on
+    for _ = 1:100
+        d = GNSSReceiver.update(d, false, 4u"ms")
+    end
+    @test GNSSReceiver.is_ranging_ready(d)       # 600 code periods of clean evidence
+    # Both latches are monotone: a later bad patch does not revoke them.
+    for _ = 1:10
+        d = GNSSReceiver.update(d, true, 4u"ms")
+    end
+    @test GNSSReceiver.has_pulled_in(d)
+    @test GNSSReceiver.is_ranging_ready(d)
+end
+
+@testset "Ranging readiness has a timer backstop, so it cannot be blocked forever" begin
+    # The property this exists for: `settled_time` is cleared by ANY out-of-lock verdict, so an
+    # uninterrupted run of `ranging_confirm_code_periods` is a bar a satellite can fail
+    # indefinitely — and `is_in_lock` will happily keep tracking it meanwhile, which means it is
+    # excluded from the PVT solve silently and permanently. That is an availability regression,
+    # because PVT needs four satellites.
+    #
+    # The regime is real, not adversarial. Under Tracking's default noise-reference estimator
+    # the CODE detector rarely blocks the run — measured steady-state per-chunk out-of-lock
+    # rates with no handover error are 0.58 at the 30 dBHz threshold itself, 0.10 one dB above
+    # it and 0.00 from two dB up — but the CARRIER detector does: its phase-lock indicator
+    # needs 460 to 590 code periods to come up through the handover (measured on GPS L1 C/A at
+    # 34 dBHz), well after the code detector is happy, and `is_ranging_ready` on a
+    # `ReceiverSatState` ANDs the two. Either way the deterministic case decides it: any
+    # disturbance recurring on a period shorter than the required run defeats the evidence
+    # path at every C/N0, which is what the sweep below covers.
+    #
+    # Any disturbance recurring faster than the required run defeats the evidence path, so it is
+    # tested over a range of periods, including 2 — a 50% duty cycle, which also defeats the
+    # obvious alternative of accumulating the evidence cumulatively with payback (zero net drift,
+    # so a paying accumulator never reaches the bar either).
+    for period in (2, 4, 10, 20, 50, 150)
+        dwell = GNSSReceiver.LockDwell(; reference_integration_time = REFERENCE_T)
+        for i = 1:1000                       # 4 s of signal
+            dwell = GNSSReceiver.update(dwell, mod(i, period) == 0, 4u"ms")
+        end
+        @test GNSSReceiver.is_in_lock(dwell)         # tracked throughout
+        @test GNSSReceiver.has_pulled_in(dwell)      # and pulled in, via its own timer
+        @test dwell.settled_time < dwell.ranging_confirm_time_threshold  # never a clean run
+        @test GNSSReceiver.is_ranging_ready(dwell)   # yet admitted to ranging, by the backstop
+    end
+
+    # It latches on the timer, at the timer — not earlier, not on the evidence path.
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        ranging_pull_in_code_periods = 2000,
+    )
+    for i = 1:500
+        dwell = GNSSReceiver.update(dwell, isodd(i), 4u"ms")
+        @test GNSSReceiver.is_ranging_ready(dwell) == (dwell.elapsed >= 2000u"ms")
+    end
+
+    # A healthy satellite still latches on the evidence, well before the timer: the documented
+    # GPS L1 C/A behaviour (80 code periods of warm-up plus 600 of clean evidence) is unchanged.
+    healthy = GNSSReceiver.LockDwell(;
+        reference_integration_time = GNSSReceiver.primary_code_period(GPSL1CA()),
+    )
+    ready_at = nothing
+    for _ = 1:1000
+        healthy = GNSSReceiver.update(healthy, false, 4u"ms")
+        GNSSReceiver.is_ranging_ready(healthy) && ready_at === nothing &&
+            (ready_at = healthy.elapsed)
+    end
+    @test ready_at ≈ 680u"ms"
+    @test ready_at < healthy.ranging_pull_in_time_threshold
+
+    # On GPS L1 C/A the backstop is 2 s, exactly `receive`'s default
+    # `time_in_lock_before_calculating_pvt` — `time_in_lock` accumulates from the handover at the
+    # same rate as `elapsed`, so the backstop costs no time to first fix there at all.
+    @test healthy.ranging_pull_in_time_threshold ≈ 2u"s"
+    # Two code-loop time constants (`1/B_L` = 1000 code periods): the loop has had over three
+    # times the elapsed time the evidence path needs, so the handover residual the backstop
+    # admits is smaller than the 2-27 m the evidence path already accepts.
+    @test healthy.ranging_pull_in_time_threshold ≈ 2 * 1000 * 1u"ms"
+
+    # The backstop is guarded, so a channel that is genuinely failing is dropped by `is_in_lock`
+    # rather than admitted by the timer. A dwell whose clock is over the steady-state threshold
+    # when the timer expires is NOT admitted; it is admitted once the clock is paid back down.
+    guarded = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        out_of_lock_code_periods = 200,
+        pull_in_out_of_lock_code_periods = 600,
+        pull_in_code_periods = 100,
+        # Short enough that the 300 ms of accumulation below happens after the backstop has
+        # expired, which is the situation the guard exists for. `ranging_confirm` has to come
+        # down with it, since the backstop is floored at it.
+        ranging_confirm_code_periods = 100,
+        ranging_pull_in_code_periods = 200,
+    )
+    for _ = 1:75                            # 300 ms out of lock: over the steady threshold
+        guarded = GNSSReceiver.update(guarded, true, 4u"ms")
+    end
+    @test guarded.elapsed >= guarded.ranging_pull_in_time_threshold
+    @test guarded.out_of_lock_time > guarded.out_of_lock_time_threshold
+    @test !GNSSReceiver.is_ranging_ready(guarded)
+    for _ = 1:30                            # pay it back below the steady threshold
+        guarded = GNSSReceiver.update(guarded, false, 4u"ms")
+    end
+    @test GNSSReceiver.is_ranging_ready(guarded)
+
+    # Sustained failure is never admitted: pure out-of-lock evidence loses lock and stays out.
+    failing = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+    )
+    for _ = 1:1000
+        failing = GNSSReceiver.update(failing, true, 4u"ms")
+    end
+    @test !GNSSReceiver.is_in_lock(failing)
+    @test !GNSSReceiver.is_ranging_ready(failing)
+
+    # `is_ranging_ready ⟹ has_pulled_in` holds structurally, not by the thresholds happening to
+    # be ordered: the timer path takes the freshly computed `pulled_in` as a conjunct, so even a
+    # backstop configured to expire before the pull-in timer cannot admit ranging first.
+    perverse = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        confirm_code_periods = 10_000,       # `pulled_in`'s evidence path can never fire, so
+        pull_in_code_periods = 800,          # only its timer, at 800 code periods, can promote
+        ranging_confirm_code_periods = 100,  # and ranging's evidence path never fires either,
+        ranging_pull_in_code_periods = 100,  # so only its backstop, at 100, can admit
+    )
+    # Alternating evidence never builds a 100-code-period run, so neither evidence path can fire
+    # here; the backstop is 700 code periods early, and must still wait for `pulled_in`.
+    longest_run = 0u"ms"
+    for i = 1:400
+        perverse = GNSSReceiver.update(perverse, isodd(i), 4u"ms")
+        longest_run = max(longest_run, perverse.settled_time)
+        GNSSReceiver.is_ranging_ready(perverse) && @test GNSSReceiver.has_pulled_in(perverse)
+    end
+    @test longest_run <= 4.001u"ms"
+    @test GNSSReceiver.has_pulled_in(perverse)
+    @test GNSSReceiver.is_ranging_ready(perverse)
+
+    # And floored at `ranging_confirm_code_periods`: a backstop expiring before the evidence path
+    # could fire would replace the criterion rather than back it up.
+    floored_backstop = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        ranging_confirm_code_periods = 600,
+        ranging_pull_in_code_periods = 100,
+    )
+    @test floored_backstop.ranging_pull_in_time_threshold >=
+          floored_backstop.ranging_confirm_time_threshold
+
+    # The backstop must not touch the dwell: a fade after a successful handover is still noticed
+    # on the steady-state timescale (200 code periods), which is the whole reason the two latches
+    # are separate in the first place.
+    faded = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+    )
+    for _ = 1:200
+        faded = GNSSReceiver.update(faded, false, 4u"ms")
+    end
+    @test GNSSReceiver.is_ranging_ready(faded)
+    fade_chunks = 0
+    while GNSSReceiver.is_in_lock(faded)
+        faded = GNSSReceiver.update(faded, true, 4u"ms")
+        fade_chunks += 1
+    end
+    @test 50 <= fade_chunks <= 51                # 200 ms, not the 600 ms pull-in allowance
+    @test GNSSReceiver.is_ranging_ready(faded)   # still monotone through the fade
+end
+
+@testset "LockDwell rejects a configuration that would silently kill the channel" begin
+    # These counts are multiplied by the code period into thresholds, so a bad one is not
+    # rejected anywhere downstream — it just scales into a threshold that is never met. A
+    # negative dwell makes `out_of_lock_time < threshold` false from the first update, i.e. a
+    # channel that is out of lock before it has seen any evidence, and a zero one does the same
+    # because `is_in_lock` tests `<`. Fail loudly at construction instead.
+    ok(; kwargs...) = GNSSReceiver.LockDwell(; reference_integration_time = REFERENCE_T, kwargs...)
+    @test ok() isa GNSSReceiver.LockDwell
+    for zero_allowed in (
+        :warm_up_code_periods,
+        :pull_in_code_periods,
+        :confirm_code_periods,
+        :ranging_confirm_code_periods,
+        :ranging_pull_in_code_periods,
+    )
+        @test ok(; (zero_allowed => 0,)...) isa GNSSReceiver.LockDwell
+        @test_throws ArgumentError ok(; (zero_allowed => -1,)...)
+        @test_throws ArgumentError ok(; (zero_allowed => NaN,)...)
+    end
+    # The two dwells additionally have to be strictly positive.
+    for dwell_kwarg in (:out_of_lock_code_periods, :pull_in_out_of_lock_code_periods)
+        @test_throws ArgumentError ok(; (dwell_kwarg => 0,)...)
+        @test_throws ArgumentError ok(; (dwell_kwarg => -200,)...)
+        @test_throws ArgumentError ok(; (dwell_kwarg => Inf,)...)
+    end
+    # `reference_integration_time` is one primary code period, so it has to be a positive
+    # duration; zero would collapse every threshold to zero at once.
+    @test_throws ArgumentError GNSSReceiver.LockDwell(; reference_integration_time = 0u"ms")
+    @test_throws ArgumentError GNSSReceiver.LockDwell(; reference_integration_time = -1u"ms")
+    @test_throws ArgumentError GNSSReceiver.LockDwell(; reference_integration_time = Inf * u"s")
+end
+
+@testset "LockDwell needs an uninterrupted run to confirm" begin
+    # A satellite that only intermittently looks good must NOT be promoted to steady state
+    # early — that is the regime a struggling pull-in is in, and it needs the credit.
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        confirm_code_periods = 200,
+        pull_in_code_periods = 800,
+    )
+    for i = 1:150
+        dwell = GNSSReceiver.update(dwell, isodd(i), 4u"ms")
+        # Every other chunk is favourable, so the run never gets past a single chunk.
+        @test dwell.settled_time <= 4.001u"ms"
+    end
+    # 600 ms of alternating evidence never accumulated a 200 ms clean run.
+    @test dwell.elapsed ≈ 600u"ms"
+    @test !dwell.pulled_in
+end
+
+@testset "LockDwell never declares loss at the stage transition" begin
+    # Accumulate more than the steady-state threshold during pull-in, then let the pull-in
+    # timer expire. If the tighter threshold simply took over, the satellite would be
+    # declared lost on the spot; the latch must wait until the clock is back under it.
+    dwell = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        out_of_lock_code_periods = 200,
+        pull_in_out_of_lock_code_periods = 600,
+        # Long enough that the whole 300 ms of accumulation below happens inside the
+        # pull-in window, so the window expires with the clock already over the
+        # steady-state threshold — the situation the guard exists for.
+        pull_in_code_periods = 300,
+    )
+    for _ = 1:75
+        dwell = GNSSReceiver.update(dwell, true, 4u"ms")
+    end
+    @test dwell.out_of_lock_time ≈ 300u"ms"   # over the steady threshold
+    @test dwell.elapsed >= dwell.pull_in_time_threshold
+    @test !dwell.pulled_in                     # so it has NOT been promoted
+    @test GNSSReceiver.is_in_lock(dwell)       # and is still held
+
+    # Paying the clock back down below the steady threshold promotes it, and it stays
+    # locked throughout — no discontinuity.
+    for _ = 1:30
+        dwell = GNSSReceiver.update(dwell, false, 4u"ms")
+        @test GNSSReceiver.is_in_lock(dwell)
+    end
+    @test dwell.pulled_in
+    @test dwell.out_of_lock_time < 200u"ms"
+end
+
+@testset "LockDwell credits good evidence by payback or by reset" begin
+    paying = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        resets_on_lock = false,
+    )
+    resetting = GNSSReceiver.LockDwell(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = 0,
+        resets_on_lock = true,
+    )
+    for _ = 1:25
+        paying = GNSSReceiver.update(paying, true, 4u"ms")
+        resetting = GNSSReceiver.update(resetting, true, 4u"ms")
+    end
+    @test paying.out_of_lock_time ≈ 100u"ms"
+    @test resetting.out_of_lock_time ≈ 100u"ms"
+
+    # One good chunk: the paying dwell gives back one chunk, the resetting one clears.
+    paying = GNSSReceiver.update(paying, false, 4u"ms")
+    resetting = GNSSReceiver.update(resetting, false, 4u"ms")
+    @test paying.out_of_lock_time ≈ 96u"ms"
+    @test resetting.out_of_lock_time == 0u"s"
+
+    # Payback never goes negative.
+    for _ = 1:100
+        paying = GNSSReceiver.update(paying, false, 4u"ms")
+    end
+    @test paying.out_of_lock_time == 0u"s"
+end
+
+# ---------------------------------------------------------------------------------------
+# CodeLockDetector
+# ---------------------------------------------------------------------------------------
+
 @testset "Detector timings scale with the primary code period" begin
     # This is the headline fix: the same code-period counts must become proportionally
     # longer absolute times on a longer code, because Tracking's loop bandwidths are
@@ -9,12 +422,20 @@ const REFERENCE_T = 1u"ms"
     for (code_period, factor) in ((1u"ms", 1), (4u"ms", 4), (10u"ms", 10))
         code = GNSSReceiver.CodeLockDetector(; reference_integration_time = code_period)
         @test code.reference_integration_time ≈ code_period
-        @test code.out_of_lock_time_threshold ≈ factor * 200u"ms"
-        @test code.wait_time_threshold ≈ factor * 80u"ms"
+        @test code.dwell.out_of_lock_time_threshold ≈ factor * 200u"ms"
+        @test code.dwell.warm_up_time_threshold ≈ factor * 80u"ms"
+        @test code.dwell.pull_in_out_of_lock_time_threshold ≈ factor * 600u"ms"
+        @test code.dwell.pull_in_time_threshold ≈ factor * 800u"ms"
+        @test code.dwell.confirm_time_threshold ≈ factor * 200u"ms"
+        @test code.dwell.ranging_confirm_time_threshold ≈ factor * 600u"ms"
+        @test code.dwell.ranging_pull_in_time_threshold ≈ factor * 2000u"ms"
 
         carrier = GNSSReceiver.CarrierLockDetector(; reference_integration_time = code_period)
-        @test carrier.out_of_lock_time_threshold ≈ factor * 4u"s"
-        @test carrier.wait_time_threshold ≈ factor * 80u"ms"
+        @test carrier.dwell.out_of_lock_time_threshold ≈ factor * 4u"s"
+        @test carrier.dwell.warm_up_time_threshold ≈ factor * 80u"ms"
+        # `pull_in_out_of_lock_code_periods` is floored at the steady value, so the carrier
+        # detector's two stages are equal: it is deliberately unstaged.
+        @test carrier.dwell.pull_in_out_of_lock_time_threshold ≈ factor * 4u"s"
     end
 
     # On GPS L1 C/A the defaults reproduce the historical absolute timings exactly, so the
@@ -22,20 +443,20 @@ const REFERENCE_T = 1u"ms"
     l1ca = GNSSReceiver.primary_code_period(GPSL1CA())
     @test GNSSReceiver.CodeLockDetector(;
         reference_integration_time = l1ca,
-    ).out_of_lock_time_threshold ≈ 200u"ms"
+    ).dwell.out_of_lock_time_threshold ≈ 200u"ms"
     @test GNSSReceiver.CarrierLockDetector(;
         reference_integration_time = l1ca,
-    ).out_of_lock_time_threshold ≈ 4u"s"
+    ).dwell.out_of_lock_time_threshold ≈ 4u"s"
 
     # Tracking reports integration times in `Hz^-1`; that must configure identically, so the
     # constructors have to `uconvert` rather than assume seconds.
     in_inverse_hz = uconvert(u"Hz^-1", 4u"ms")
     @test GNSSReceiver.CodeLockDetector(;
         reference_integration_time = in_inverse_hz,
-    ).out_of_lock_time_threshold ≈ 800u"ms"
+    ).dwell.out_of_lock_time_threshold ≈ 800u"ms"
     @test GNSSReceiver.CarrierLockDetector(;
         reference_integration_time = in_inverse_hz,
-    ).wait_time_threshold ≈ 320u"ms"
+    ).dwell.warm_up_time_threshold ≈ 320u"ms"
 
     # A count that cannot describe a timing is rejected rather than silently scaled into a
     # negative threshold, which would read as "out of lock" from the very first update.
@@ -62,20 +483,23 @@ end
         detector = GNSSReceiver.update(detector, 45u"dBHz", REFERENCE_T, 4u"ms")
     end
     @test GNSSReceiver.is_in_lock(detector)
-    @test detector.out_of_lock_time == 0u"s"
+    @test detector.dwell.out_of_lock_time == 0u"s"
 
-    # CN0 below threshold accumulates out-of-lock time until lock is declared lost.
-    for _ = 1:60
+    # CN0 below threshold accumulates out-of-lock time until lock is declared lost. A fresh
+    # detector is still in its pull-in stage, so what it tolerates is the 600-code-period
+    # pull-in allowance, not the 200 of steady state: 150 updates of 4 ms.
+    for _ = 1:150
         detector = GNSSReceiver.update(detector, 10u"dBHz", REFERENCE_T, 4u"ms")
     end
     @test !GNSSReceiver.is_in_lock(detector)
-    @test detector.out_of_lock_time >= 200u"ms"
+    @test detector.dwell.out_of_lock_time >= 600u"ms"
+    @test !GNSSReceiver.has_pulled_in(detector)
 
     # A healthy CN0 again pays the accumulated out-of-lock time back down.
-    accumulated = detector.out_of_lock_time
+    accumulated = detector.dwell.out_of_lock_time
     detector = GNSSReceiver.update(detector, 45u"dBHz", REFERENCE_T, 4u"ms")
-    @test detector.out_of_lock_time < accumulated
-    @test detector.out_of_lock_time == accumulated - 4u"ms"
+    @test detector.dwell.out_of_lock_time < accumulated
+    @test detector.dwell.out_of_lock_time == accumulated - 4u"ms"
 end
 
 @testset "CodeLockDetector caps the out-of-lock dwell so recovery is bounded" begin
@@ -96,16 +520,41 @@ end
         detector = GNSSReceiver.update(detector, 10u"dBHz", REFERENCE_T, 4u"ms")
     end
     @test !GNSSReceiver.is_in_lock(detector)
-    @test detector.out_of_lock_time ==
-          GNSSReceiver.OUT_OF_LOCK_TIME_CAP_FACTOR * detector.out_of_lock_time_threshold
+    # The cap follows the *current stage*, not the fixed steady-state threshold. Capping a
+    # pull-in detector at twice 200 ms would silently truncate its 600 ms allowance to 400.
+    @test !GNSSReceiver.has_pulled_in(detector)
+    @test detector.dwell.out_of_lock_time ==
+          GNSSReceiver.OUT_OF_LOCK_TIME_CAP_FACTOR *
+          GNSSReceiver.current_out_of_lock_time_threshold(detector)
+    @test detector.dwell.out_of_lock_time == 1200u"ms"
 
-    # One threshold's worth of good signal therefore brings it back, not sixty seconds':
-    # 51 updates of 4 ms pay 204 ms off the 400 ms cap, crossing back under the threshold.
-    for _ = 1:51
+    # One stage threshold's worth of good signal therefore brings it back, not sixty
+    # seconds': 151 updates of 4 ms pay 604 ms off the 1200 ms cap, crossing back under the
+    # 600 ms the pull-in stage tolerates.
+    for _ = 1:151
         detector = GNSSReceiver.update(detector, 45u"dBHz", REFERENCE_T, 4u"ms")
     end
     @test GNSSReceiver.is_in_lock(detector)
-    @test detector.out_of_lock_time < detector.out_of_lock_time_threshold
+    @test detector.dwell.out_of_lock_time <
+          GNSSReceiver.current_out_of_lock_time_threshold(detector)
+
+    # Once the handover has latched closed the cap tightens with the stage: twice 200 ms.
+    settled = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30u"dBHz",
+        reference_integration_time = REFERENCE_T,
+    )
+    for _ = 1:100
+        settled = GNSSReceiver.update(settled, 45u"dBHz", REFERENCE_T, 4u"ms")
+    end
+    @test GNSSReceiver.has_pulled_in(settled)
+    for _ = 1:15_000
+        settled = GNSSReceiver.update(settled, 10u"dBHz", REFERENCE_T, 4u"ms")
+    end
+    @test settled.dwell.out_of_lock_time == 400u"ms"
+    for _ = 1:51
+        settled = GNSSReceiver.update(settled, 45u"dBHz", REFERENCE_T, 4u"ms")
+    end
+    @test GNSSReceiver.is_in_lock(settled)
 end
 
 @testset "CodeLockDetector stays neutral before the wait time elapses" begin
@@ -117,7 +566,7 @@ end
         warm_up_code_periods = 80,
     )
     detector = GNSSReceiver.update(detector, 5u"dBHz", REFERENCE_T, 4u"ms")
-    @test detector.out_of_lock_time == 0u"s"
+    @test detector.dwell.out_of_lock_time == 0u"s"
     @test GNSSReceiver.is_in_lock(detector)
 end
 
@@ -181,6 +630,65 @@ end
     @test GNSSReceiver.is_below_cn0_threshold(detector, minus_inf_cn0, 20 * REFERENCE_T)
 end
 
+@testset "CodeLockDetector survives the handover transient it used to fail" begin
+    # The bug this staging exists to fix, reduced to a deterministic regression. A marginal
+    # satellite reads several dB below its true C/N0 through the handover, because the prompt
+    # sits off the correlation peak until the loops have pulled the coarse acquisition
+    # estimate in. Measured on synthetic handovers at this receiver's own worst-case residual,
+    # the peak accumulated out-of-lock demand for a satellite the receiver should keep is 292
+    # code periods (GPS L1 C/A at 32 dBHz), and it runs into the thousands within a dB of
+    # threshold — against a steady-state dwell of 200.
+    #
+    # Replayed here on a 10 ms code, where the old absolute 200 ms dwell is only 20 code
+    # periods: a satellite 4 dB under threshold for 2.5 s is dropped by that configuration and
+    # held by the scaled, staged one.
+    code_period = GNSSReceiver.primary_code_period(GPSL1C_D())
+    @test code_period ≈ 10u"ms"
+    transient_cn0 = 26u"dBHz"
+    recovered_cn0 = 40u"dBHz"
+
+    scaled = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30u"dBHz",
+        reference_integration_time = code_period,
+    )
+    absolute = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30u"dBHz",
+        reference_integration_time = code_period,
+        old_absolute_code_kwargs(code_period)...,
+    )
+    # 2.5 s of depressed CN0 at 10 ms records, then recovery.
+    for _ = 1:250
+        scaled = GNSSReceiver.update(scaled, transient_cn0, code_period, 10u"ms")
+        absolute = GNSSReceiver.update(absolute, transient_cn0, code_period, 10u"ms")
+    end
+    @test !GNSSReceiver.is_in_lock(absolute)   # the old configuration drops it
+    @test GNSSReceiver.is_in_lock(scaled)      # the new one holds it
+
+    # Recovery: 1.7 s of accumulated out-of-lock time to pay back, then `confirm_code_periods`
+    # (200, i.e. 2 s here) of uninterrupted good evidence to leave the pull-in stage.
+    for _ = 1:400
+        scaled = GNSSReceiver.update(scaled, recovered_cn0, code_period, 10u"ms")
+    end
+    @test GNSSReceiver.is_in_lock(scaled)
+    @test scaled.dwell.out_of_lock_time == 0u"s"
+    @test scaled.dwell.pulled_in
+    # It latched on the evidence, not on the timer — `pull_in_time_threshold` is 8 s here
+    # and only 6.5 s of signal has passed.
+    @test scaled.dwell.elapsed < scaled.dwell.pull_in_time_threshold
+
+    # Having converged, it is now held to the steady-state timescale: a genuine fade is
+    # noticed after 200 code periods — 2 s on this 10 ms code — rather than after the
+    # generous 600-period pull-in allowance.
+    for _ = 1:199
+        scaled = GNSSReceiver.update(scaled, 5u"dBHz", code_period, 10u"ms")
+    end
+    @test GNSSReceiver.is_in_lock(scaled)
+    for _ = 1:2
+        scaled = GNSSReceiver.update(scaled, 5u"dBHz", code_period, 10u"ms")
+    end
+    @test !GNSSReceiver.is_in_lock(scaled)
+end
+
 @testset "ReceiverSatState anchors the threshold to the ranging signal's code period" begin
     # The reference must come from the signal the detector actually runs on, not from a
     # hard-coded 1 ms: GPS L1 C/A's code period is 1 ms, Galileo E1B's is 4 ms.
@@ -193,8 +701,8 @@ end
     @test state.code_lock_detector.reference_integration_time ==
           GNSSReceiver.primary_code_period(GPSL1CA())
     # Both detectors must be anchored, not just the code one.
-    @test state.code_lock_detector.out_of_lock_time_threshold ≈ 200u"ms"
-    @test state.carrier_lock_detector.out_of_lock_time_threshold ≈ 4u"s"
+    @test state.code_lock_detector.dwell.out_of_lock_time_threshold ≈ 200u"ms"
+    @test state.carrier_lock_detector.dwell.out_of_lock_time_threshold ≈ 4u"s"
 
     # Galileo E1B's 4 ms code period gives timings 4× longer, matching its 4× slower loops —
     # the property whose absence made lock detection fail on the slower signals. Built from
@@ -205,10 +713,10 @@ end
     e1b_period = GNSSReceiver.primary_code_period(GalileoE1B())
     @test GNSSReceiver.CodeLockDetector(;
         reference_integration_time = e1b_period,
-    ).out_of_lock_time_threshold ≈ 800u"ms"
+    ).dwell.out_of_lock_time_threshold ≈ 800u"ms"
     @test GNSSReceiver.CarrierLockDetector(;
         reference_integration_time = e1b_period,
-    ).out_of_lock_time_threshold ≈ 16u"s"
+    ).dwell.out_of_lock_time_threshold ≈ 16u"s"
 end
 
 # ---------------------------------------------------------------------------------------
@@ -462,11 +970,15 @@ end
     @test 0.1 < false_alarm_one_block < 0.35
 
     # The out-of-lock dwell is what actually suppresses those transients: end to end, pure
-    # noise loses lock for every record length.
+    # noise loses lock for every record length. 500 updates rather than 200, because a fresh
+    # detector is in its pull-in stage (600 code periods) and the moment ratio pays time back
+    # on the ~22% of noise realizations that clear the threshold, so the clock climbs at only
+    # ~0.55 of `signal_duration` per update.
     for num_code_blocks in (1, 20)
-        driven = synthetic_drive(synthetic_detector(), 0.0dBHz, num_code_blocks, 1:200)
+        driven = synthetic_drive(synthetic_detector(), 0.0dBHz, num_code_blocks, 1:500)
         @test !GNSSReceiver.is_in_lock(driven)
-        @test driven.out_of_lock_time >= driven.out_of_lock_time_threshold
+        @test driven.dwell.out_of_lock_time >=
+              GNSSReceiver.current_out_of_lock_time_threshold(driven)
     end
 end
 
@@ -489,10 +1001,10 @@ end
 
     # The consequence end to end: the out-of-lock dwell is spent monotonically instead of
     # being paid back on the realizations the moment ratio let through, so lock is lost in
-    # exactly the warm-up plus the out-of-lock dwell — 20 + 50 updates
-    # of 4 ms — rather than the ~85 the moment ratio needs.
+    # exactly the warm-up plus the dwell the detector's *current stage* allows — a fresh
+    # detector is in pull-in, so 20 + 150 updates of 4 ms.
     duration = 4u"ms"
-    for num_updates in (69, 70)
+    for num_updates in (169, 170)
         driven = synthetic_drive(
             synthetic_detector(),
             0.0dBHz,
@@ -501,8 +1013,8 @@ end
             signal_duration = duration,
             make_estimator = default_estimator,
         )
-        @test GNSSReceiver.is_in_lock(driven) == (num_updates < 70)
-        @test driven.out_of_lock_time ≈ (num_updates - 20) * duration
+        @test GNSSReceiver.is_in_lock(driven) == (num_updates < 170)
+        @test driven.dwell.out_of_lock_time ≈ (num_updates - 20) * duration
     end
 end
 
@@ -519,26 +1031,29 @@ end
     # that pass) and needs ~85 updates to cross a 200 ms threshold. 200 updates leaves
     # comfortable margin; the noise reference gets there in 70.
 
-    # A healthy signal warms up and stays locked.
+    # A healthy signal warms up, stays locked, and latches out of its pull-in stage.
     healthy = synthetic_drive(synthetic_detector(), 45.0dBHz, 1, 1:200; make_estimator)
     @test GNSSReceiver.is_in_lock(healthy)
-    @test healthy.out_of_lock_time == 0u"s"
+    @test healthy.dwell.out_of_lock_time == 0u"s"
+    @test GNSSReceiver.has_pulled_in(healthy)
 
-    # Then it collapses: lock is lost once `out_of_lock_time_threshold` accumulates.
+    # Then it collapses: lock is lost once the steady-state dwell accumulates — the tighter
+    # threshold, because the handover latched closed while the signal was healthy.
     collapsed = synthetic_drive(healthy, 5.0dBHz, 1, 201:400; make_estimator)
     @test !GNSSReceiver.is_in_lock(collapsed)
-    @test collapsed.out_of_lock_time >= collapsed.out_of_lock_time_threshold
+    @test collapsed.dwell.out_of_lock_time >=
+          GNSSReceiver.current_out_of_lock_time_threshold(collapsed)
 
     # A 20 dBHz signal is 10 dB under the threshold, so one-block records drop it — but
     # 20-block records hold it without ever accumulating any out-of-lock time at all,
     # because the 13 dB of credited integration time covers the shortfall. Same CN0, same
     # code path; only the record length differs. This is the fix in one comparison.
-    on_one_block = synthetic_drive(synthetic_detector(), 20.0dBHz, 1, 1:200; make_estimator)
+    on_one_block = synthetic_drive(synthetic_detector(), 20.0dBHz, 1, 1:500; make_estimator)
     on_twenty_blocks =
-        synthetic_drive(synthetic_detector(), 20.0dBHz, 20, 1:200; make_estimator)
+        synthetic_drive(synthetic_detector(), 20.0dBHz, 20, 1:500; make_estimator)
     @test !GNSSReceiver.is_in_lock(on_one_block)
     @test GNSSReceiver.is_in_lock(on_twenty_blocks)
-    @test on_twenty_blocks.out_of_lock_time == 0u"s"
+    @test on_twenty_blocks.dwell.out_of_lock_time == 0u"s"
 end
 
 # ---------------------------------------------------------------------------------------
@@ -602,7 +1117,7 @@ end
     end
     @test GNSSReceiver.phase_lock_indicator(detector) < 0
     @test GNSSReceiver.is_below_phase_lock_threshold(detector)
-    @test detector.out_of_lock_time > 0u"s"
+    @test detector.dwell.out_of_lock_time > 0u"s"
 
     # Sustained, it loses lock once the 4 s dwell is exhausted.
     for _ = 1:1000
@@ -624,7 +1139,7 @@ end
     @test GNSSReceiver.phase_lock_indicator(detector) > 0.25
     # Once the indicator is back above threshold the accumulated time clears outright —
     # the "optimistic" credit, so a *consecutive* run of failures is needed to declare loss.
-    @test detector.out_of_lock_time == 0u"s"
+    @test detector.dwell.out_of_lock_time == 0u"s"
     @test GNSSReceiver.is_in_lock(detector)
 end
 
@@ -638,7 +1153,7 @@ end
         detector = GNSSReceiver.update(detector, prompt, 4u"ms")
     end
     @test GNSSReceiver.is_in_lock(detector)
-    @test detector.out_of_lock_time <= 4.001u"ms"
+    @test detector.dwell.out_of_lock_time <= 4.001u"ms"
 end
 
 @testset "CarrierLockDetector uses every prompt of the chunk" begin
@@ -715,7 +1230,7 @@ end
     # An empty prompt sequence (no record completed this chunk) still advances the timers
     # without inventing evidence.
     empty_chunk = GNSSReceiver.update(fresh, ComplexF64[], 4u"ms")
-    @test empty_chunk.wait_time ≈ 4u"ms"
+    @test empty_chunk.dwell.elapsed ≈ 4u"ms"
     @test isnan(GNSSReceiver.phase_lock_indicator(empty_chunk))
     @test GNSSReceiver.is_in_lock(empty_chunk)
 end
@@ -741,8 +1256,8 @@ end
     # 50 chunks of 40 ms against one of 4 ms: 500× the signal time, the same 50 gain steps.
     # The timers, driven by `signal_duration`, do see the difference — the second detector
     # has run its warm-up out while the first has barely started it.
-    @test over_one_chunk.wait_time ≈ 4u"ms"
-    @test over_fifty_chunks.wait_time ≈ over_fifty_chunks.wait_time_threshold
+    @test over_one_chunk.dwell.elapsed ≈ 4u"ms"
+    @test over_fifty_chunks.dwell.elapsed ≈ 2u"s"
 end
 
 @testset "CarrierLockDetector rejects a configuration that would silently kill the channel" begin
@@ -754,16 +1269,7 @@ end
     @test isnan(
         GNSSReceiver.phase_lock_indicator(
             GNSSReceiver.update(
-                GNSSReceiver.CarrierLockDetector(
-                    0.0,
-                    0.0,
-                    Inf,
-                    0.25,
-                    0.0u"s",
-                    4u"s",
-                    80u"ms",
-                    80u"ms",
-                ),
+                GNSSReceiver.CarrierLockDetector(0.0, 0.0, Inf, 0.25, carrier_detector().dwell),
                 complex(1.0, 0.0),
                 4u"ms",
             ),
@@ -787,6 +1293,13 @@ end
     @test_throws ArgumentError carrier_detector(; phase_lock_threshold = -1.0)
     @test_throws ArgumentError carrier_detector(; phase_lock_threshold = NaN)
     @test carrier_detector(; phase_lock_threshold = 0.9) isa GNSSReceiver.CarrierLockDetector
+
+    # The dwell's own validation reaches through the detector constructors' `dwell_kwargs...`.
+    @test_throws ArgumentError carrier_detector(; out_of_lock_code_periods = 0)
+    @test_throws ArgumentError GNSSReceiver.CodeLockDetector(;
+        reference_integration_time = REFERENCE_T,
+        warm_up_code_periods = -80,
+    )
 end
 
 @testset "CarrierLockDetector's quoted noise figures are asymptotic" begin
@@ -815,7 +1328,11 @@ end
     # The warm-up is deliberately not lengthened to the window: clearing the dwell on any
     # favourable chunk, together with the 4000-code-period dwell, means loss needs a
     # *consecutive* run of failures, so an early excursion in either direction is absorbed.
-    @test carrier_detector().wait_time_threshold ≈ 80u"ms"
+    @test carrier_detector().dwell.warm_up_time_threshold ≈ 80u"ms"
+    # Raising the carrier warm-up to match the window would push `is_ranging_ready` — which
+    # ANDs both detectors — from 680 code periods out to 800.
+    @test carrier_detector().dwell.warm_up_time_threshold +
+          carrier_detector().dwell.ranging_confirm_time_threshold ≈ 680u"ms"
     # In the false-drop direction the early window is already tight enough: at the code-lock
     # threshold (ρ = 1, perfect phase lock) the indicator is essentially never below 0.25.
     at_threshold = map(1:1000) do seed

--- a/test/process.jl
+++ b/test/process.jl
@@ -161,16 +161,25 @@ end
 # `time_out_of_lock` is the `ReceiverSatState`'s own out-of-lock timer, which gates
 # the reacquisition back-off (`should_reacquire`) — pass a value past the first
 # back-off step (200 ms) to make the sat eligible for reacquisition.
-out_of_lock_code_detector() =
-    GNSSReceiver.CodeLockDetector(
-        30.0u"dBHz",
-        1u"ms",       # reference_integration_time: GPS L1 C/A's code period
-        Inf * u"s",   # coherence_limit: uncapped
-        250u"ms",
-        200u"ms",
-        80u"ms",
-        80u"ms",
+# Driven through `update` rather than written field by field, so it stays correct across a
+# retuning of the stage timings (and across the struct layout, which now nests a `LockDwell`).
+function out_of_lock_code_detector()
+    detector = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30.0u"dBHz",
+        # GPS L1 C/A's code period, which every timing is a multiple of.
+        reference_integration_time = 1u"ms",
     )
+    # Enough clean evidence to latch out of the pull-in stage, so the loop below only has to
+    # spend the (tighter) steady-state dwell.
+    for _ = 1:100
+        detector = GNSSReceiver.update(detector, 45.0u"dBHz", 1u"ms", 4u"ms")
+    end
+    @assert GNSSReceiver.has_pulled_in(detector)
+    while GNSSReceiver.is_in_lock(detector)
+        detector = GNSSReceiver.update(detector, 0.0u"dBHz", 1u"ms", 4u"ms")
+    end
+    detector
+end
 
 function out_of_lock_sat_state(system, prn; time_out_of_lock = 0.0u"s")
     GNSSReceiver.ReceiverSatState(
@@ -208,13 +217,213 @@ function single_sat_track_state(system, prn; num_ants = NumAnts(1))
     )
 end
 
+
+# ---------------------------------------------------------------------------------------
+# The ranging-readiness gate on the PVT solve. `is_in_lock` is deliberately generous
+# through the acquisition → tracking handover so a converging satellite is kept rather than
+# dropped and reacquired; `is_ranging_ready` is what stops that tolerance from leaking a
+# code phase that is still walking the coarse acquisition estimate in — a pseudorange wrong
+# by metres to tens of metres — into the solve. The gate lives in `collect_pvt_sat_states!`,
+# so it is asserted there and not only on the detectors.
+# ---------------------------------------------------------------------------------------
+
+# GPS L1 C/A's code period, the reference integration time its detectors are configured in.
+const PVT_GATE_REFERENCE_T = 1u"ms"
+
+fresh_code_detector() = GNSSReceiver.CodeLockDetector(;
+    cn0_threshold = 30.0u"dBHz",
+    reference_integration_time = PVT_GATE_REFERENCE_T,
+)
+
+fresh_carrier_detector() =
+    GNSSReceiver.CarrierLockDetector(; reference_integration_time = PVT_GATE_REFERENCE_T)
+
+# Detectors driven to ranging readiness through `update` on healthy evidence, exactly as
+# `out_of_lock_code_detector` above drives one to loss: the helper never touches a field, so
+# it stays independent of the dwell's layout, of its stage timings and of how ranging
+# readiness is decided. The loop asks the detector instead of counting a fixed number of
+# updates (~680 code periods of clean evidence on GPS L1 C/A today), so retuning the
+# thresholds cannot silently turn this into a different test; the cap only stops a runaway
+# loop if readiness became unreachable.
+function ranging_ready_code_detector(; max_updates = 10_000)
+    detector = fresh_code_detector()
+    updates = 0
+    while !GNSSReceiver.is_ranging_ready(detector)
+        detector =
+            GNSSReceiver.update(detector, 45.0u"dBHz", PVT_GATE_REFERENCE_T, 4u"ms")
+        updates += 1
+        @assert updates <= max_updates "code detector never reported ranging readiness"
+    end
+    detector
+end
+
+function ranging_ready_carrier_detector(; max_updates = 10_000)
+    detector = fresh_carrier_detector()
+    # A strongly in-phase prompt: the phase-lock indicator converges to cos(0)·ρ/(ρ+1),
+    # far above the 0.25 threshold. Four per chunk, as a 4 ms chunk over a 1 ms code
+    # period really produces.
+    prompts = ntuple(_ -> complex(10.0, 0.1), 4)
+    updates = 0
+    while !GNSSReceiver.is_ranging_ready(detector)
+        detector = GNSSReceiver.update(detector, prompts, 4u"ms")
+        updates += 1
+        @assert updates <= max_updates "carrier detector never reported ranging readiness"
+    end
+    detector
+end
+
+# A satellite that has been in lock long past `time_in_lock_before_calculating_pvt`, so the
+# only thing the PVT gate can still object to is the state of its lock detectors.
+function pvt_sat_state(
+    system,
+    prn,
+    code_lock_detector,
+    carrier_lock_detector;
+    time_in_lock = 5.0u"s",
+    in_vt_loop = false,
+)
+    GNSSReceiver.ReceiverSatState(
+        prn,
+        GNSSDecoderState(system, prn),
+        code_lock_detector,
+        carrier_lock_detector,
+        uconvert(u"s", float(time_in_lock)),
+        0.0u"s",
+        0,
+        in_vt_loop,
+    )
+end
+
+@testset "is_ranging_ready on a ReceiverSatState needs both detectors" begin
+    system = GPSL1CA()
+    ready_code = ranging_ready_code_detector()
+    ready_carrier = ranging_ready_carrier_detector()
+    fresh_code = fresh_code_detector()
+    fresh_carrier = fresh_carrier_detector()
+
+    # The per-detector premise of the test: driven detectors are ready, fresh ones are not.
+    @test GNSSReceiver.is_ranging_ready(ready_code)
+    @test GNSSReceiver.is_ranging_ready(ready_carrier)
+    @test !GNSSReceiver.is_ranging_ready(fresh_code)
+    @test !GNSSReceiver.is_ranging_ready(fresh_carrier)
+
+    combinations = Dictionary(
+        [(false, false), (true, false), (false, true), (true, true)],
+        [
+            pvt_sat_state(system, 1, fresh_code, fresh_carrier),
+            pvt_sat_state(system, 1, ready_code, fresh_carrier),
+            pvt_sat_state(system, 1, fresh_code, ready_carrier),
+            pvt_sat_state(system, 1, ready_code, ready_carrier),
+        ],
+    )
+    # An AND, not an OR and not just one of the two: only the state whose *both* detectors
+    # have settled may be ranged on.
+    for ((code_ready, carrier_ready), state) in pairs(combinations)
+        @test GNSSReceiver.is_ranging_ready(state) == (code_ready && carrier_ready)
+        # And ranging readiness is a strictly later gate than lock: every one of these
+        # satellites is in lock, including the three that must not be ranged on.
+        @test GNSSReceiver.is_in_lock(state)
+    end
+
+    # A vector-loop member is judged on its code detector alone, mirroring `is_in_lock`. The
+    # navigation filter steers both its NCOs through an outage, so its code stays aligned
+    # while its carrier phase-lock indicator is starved of prompts — ANDing the carrier latch
+    # would permanently exclude a member that joined the loop before that latch fired.
+    @test GNSSReceiver.is_ranging_ready(
+        pvt_sat_state(system, 1, ready_code, fresh_carrier; in_vt_loop = true),
+    )
+    @test !GNSSReceiver.is_ranging_ready(
+        pvt_sat_state(system, 1, ready_code, fresh_carrier),
+    )
+    # But a member whose *code* detector has not settled is still not rangeable.
+    @test !GNSSReceiver.is_ranging_ready(
+        pvt_sat_state(system, 1, fresh_code, ready_carrier; in_vt_loop = true),
+    )
+end
+
+@testset "collect_pvt_sat_states! admits only ranging-ready satellites" begin
+    system = GPSL1CA()
+    key = get_signal_id(system)
+    track_state = single_sat_track_state(system, 5)
+    time_in_lock_before_pvt = 2u"s"
+
+    not_ready = pvt_sat_state(system, 5, fresh_code_detector(), fresh_carrier_detector())
+    ready = pvt_sat_state(
+        system,
+        5,
+        ranging_ready_code_detector(),
+        ranging_ready_carrier_detector(),
+    )
+    # The two states differ in ranging readiness and in nothing else the gate looks at:
+    # both are in lock and both are well past the time-in-lock threshold. So a satellite
+    # kept by the handover tolerance is still refused a pseudorange.
+    for state in (not_ready, ready)
+        @test GNSSReceiver.is_in_lock(state)
+        @test state.time_in_lock > time_in_lock_before_pvt
+    end
+    @test !GNSSReceiver.is_ranging_ready(not_ready)
+    @test GNSSReceiver.is_ranging_ready(ready)
+
+    states = PositionVelocityTime.SatelliteState[]
+    GNSSReceiver.collect_pvt_sat_states!(
+        states,
+        (system,),
+        (; key => Dictionary([5], [not_ready])),
+        track_state,
+        time_in_lock_before_pvt,
+    )
+    @test isempty(states)
+
+    GNSSReceiver.collect_pvt_sat_states!(
+        states,
+        (system,),
+        (; key => Dictionary([5], [ready])),
+        track_state,
+        time_in_lock_before_pvt,
+    )
+    @test length(states) == 1
+    # PVT is handed the ranging signal, and the satellite's own decoder and code phase.
+    @test states[1].system == GNSSReceiver.ranging_signal(system)
+    @test states[1].code_phase == get_code_phase(get_sat_state(track_state, key, 5))
+    @test states[1].decoder === ready.decoder
+
+    # The gate is not the time gate in disguise: readiness alone does not admit a satellite
+    # that has not yet been in lock long enough to have decoded usable data.
+    empty!(states)
+    GNSSReceiver.collect_pvt_sat_states!(
+        states,
+        (system,),
+        (;
+            key => Dictionary(
+                [5],
+                [
+                    pvt_sat_state(
+                        system,
+                        5,
+                        ranging_ready_code_detector(),
+                        ranging_ready_carrier_detector();
+                        time_in_lock = 1.0u"s",
+                    ),
+                ],
+            )
+        ),
+        track_state,
+        time_in_lock_before_pvt,
+    )
+    @test isempty(states)
+end
+
 @testset "PVT waits for the satellites' loops to settle" begin
     # `time_in_lock_before_calculating_pvt` keeps a freshly locked satellite out of the
     # solve until its loops have settled: the pseudorange is built from the tracked code
-    # phase, and during pull-in that phase is still a transient.
+    # phase, and during pull-in that phase is still a transient. Its detectors are driven to
+    # ranging readiness first, so the *time* gate is the only thing this testset varies —
+    # `is_ranging_ready`, the other half of the same conjunction, is covered above.
     system = GPSL1CA()
     key = get_signal_id(system)
     track_state = single_sat_track_state(system, 1)
+    ready_code = ranging_ready_code_detector()
+    ready_carrier = ranging_ready_carrier_detector()
     settled(time_in_lock) = (;
         key => Dictionary(
             [1],
@@ -222,8 +431,8 @@ end
                 GNSSReceiver.ReceiverSatState(
                     1,
                     GNSSDecoderState(system, 1),
-                    GNSSReceiver.CodeLockDetector(),
-                    GNSSReceiver.CarrierLockDetector(),
+                    ready_code,
+                    ready_carrier,
                     time_in_lock,
                     0.0u"s",
                     0,

--- a/test/receive.jl
+++ b/test/receive.jl
@@ -182,3 +182,57 @@ end
     @test !isempty(data)
     @test eltype(data) == Int
 end
+
+# The wiring that puts the lock stage into the emitted payload. `SatelliteDataOfInterest`
+# reports `is_ranging_ready` so that a satellite kept through the acquisition handover — in
+# lock, deliberately, but not yet trustworthy to range on — is distinguishable from one the
+# PVT solve is ignoring for no visible reason.
+@testset "Emitted satellite data reports the ranging stage" begin
+    # Detectors driven through `update`, never by writing fields, so this stays independent
+    # of the dwell's layout and of how ranging readiness is decided.
+    function ready_code_detector()
+        detector = GNSSReceiver.CodeLockDetector(;
+            cn0_threshold = 30.0u"dBHz",
+            reference_integration_time = 1u"ms",
+        )
+        updates = 0
+        while !GNSSReceiver.is_ranging_ready(detector)
+            detector = GNSSReceiver.update(detector, 45.0u"dBHz", 1u"ms", 4u"ms")
+            updates += 1
+            @assert updates <= 10_000 "detector never reported ranging readiness"
+        end
+        detector
+    end
+
+    sat_state(code_detector) = GNSSReceiver.ReceiverSatState(
+        1,
+        GNSSDecoderState(GPSL1CA(), 1),
+        code_detector,
+        GNSSReceiver.CarrierLockDetector(; reference_integration_time = 1u"ms"),
+        5.0u"s",
+        0.0u"s",
+        0,
+        false,
+    )
+
+    # A fresh detector is in lock but not ranging-ready; a driven one is both.
+    fresh = GNSSReceiver.CodeLockDetector(;
+        cn0_threshold = 30.0u"dBHz",
+        reference_integration_time = 1u"ms",
+    )
+    settling = sat_state(fresh)
+    @test GNSSReceiver.is_in_lock(settling)
+    @test !GNSSReceiver.is_ranging_ready(settling)
+
+    states = Dictionary([1], [settling])
+    @test !GNSSReceiver.is_sat_ranging_ready_at(states, 1)
+    # The carrier detector gates too, so a ready *code* detector alone is not enough.
+    @test !GNSSReceiver.is_sat_ranging_ready_at(
+        Dictionary([1], [sat_state(ready_code_detector())]),
+        1,
+    )
+    # Absent state must never read as ready — the same fail-safe direction as
+    # `is_sat_healthy_at`, which a satellite the receiver holds no state for also fails.
+    @test !GNSSReceiver.is_sat_ranging_ready_at(states, 99)
+    @test !GNSSReceiver.is_sat_healthy_at(states, 99)
+end

--- a/test/receive.jl
+++ b/test/receive.jl
@@ -235,4 +235,17 @@ end
     # `is_sat_healthy_at`, which a satellite the receiver holds no state for also fails.
     @test !GNSSReceiver.is_sat_ranging_ready_at(states, 99)
     @test !GNSSReceiver.is_sat_healthy_at(states, 99)
+
+    # The lock verdict is reported alongside it, and is NOT constant-true in the payload: a
+    # vector-loop member that has lost lock is deliberately kept in tracking
+    # (`remove_lost_satellites`), and its ranging readiness stays latched from before the
+    # outage. So readiness alone does not answer "would the receiver range on this satellite
+    # right now?" — `collect_pvt_sat_states!` requires both, and a consumer needs both.
+    @test GNSSReceiver.is_sat_in_lock_at(states, 1)
+    @test !GNSSReceiver.is_sat_in_lock_at(states, 99)
+    coasting = sat_state(GNSSReceiver.set_out_of_lock(ready_code_detector()))
+    coasting = @set coasting.in_vt_loop = true
+    coasted_states = Dictionary([1], [coasting])
+    @test GNSSReceiver.is_sat_ranging_ready_at(coasted_states, 1)
+    @test !GNSSReceiver.is_sat_in_lock_at(coasted_states, 1)
 end


### PR DESCRIPTION
## Why

Satellites bounce in and out of lock at the acquisition → tracking handover on every signal
except GPS L1 C/A. The cause is that the detector timings were **absolute seconds while the
tracking loops' time constants are not**. Tracking sizes its default bandwidths at
`B_L·T_code ≈ 0.018`, so every loop time constant scales with the primary code period:

| Signal | `T_code` | carrier `B_L` | code `B_L` | `1/B_L` carrier | `1/B_L` code |
|---|---|---|---|---|---|
| GPS L1 C/A | 1 ms | 18 Hz | 1 Hz | 56 ms | 1.0 s |
| Galileo E1B | 4 ms | 4.5 Hz | 0.25 Hz | 222 ms | 4.0 s |
| GPS L1C-D | 10 ms | 1.8 Hz | 0.1 Hz | 556 ms | 10.0 s |

The 80 ms warm-up and 200 ms dwell are 80 and 200 code periods on GPS L1 C/A — the signal they
were tuned against, and where they are correct — but only 50 on Galileo E1B and 20 on GPS L1C-D,
against loops four and ten times slower.

Measured on synthetic handovers driven through Tracking's real loops (details below), the old
configuration's grace is **280 ms of signal regardless of signal**: it drops a struggling
satellite after 280 code periods on GPS L1 C/A, 70 on Galileo E1B and **28** on GPS L1C-D —
whereupon `should_reacquire` fires it straight back into the same doomed transient.

What makes a *healthy* satellite look like a struggling one is that the handover is deliberately
coarse: the acquisition Doppler bin is half the loop's pull-in range and the code phase is only
resolved to the sample grid (halved by `subsample_interpolation`). Until the loops pull those in,
the prompt sits off the correlation peak and the carrier phase is still spinning at the residual
Doppler, so both detectors read the satellite as weak.

## What changed

Four commits, each self-contained.

**1. `feat: scale the lock detectors' timings to the ranging signal's code period.`** Every
timing is now a multiple of `reference_integration_time`, one primary code period of the signal
the detector runs on — which the receiver already threaded into `CodeLockDetector` and now
threads into `CarrierLockDetector` too. On GPS L1 C/A every default is numerically unchanged
(80 × 1 ms, 200 × 1 ms, 4000 × 1 ms). Misconfigured counts now raise `ArgumentError` instead of
scaling silently into a negative threshold, which `is_in_lock` would read as "out of lock" from
the first update.

**2. `feat: read every prompt into a Van Dierendonck carrier phase-lock indicator.`** Two
independent defects in `CarrierLockDetector`:

- **It saw one prompt in four.** `process` fed `get_last_fully_integrated_filtered_prompt`, so at
  the default 4 ms chunk over a 1 ms code period three of every four records were discarded. It
  is now fed `get_filtered_prompts` — every prompt of the chunk.
- **The statistic was wrong for the cadence.** The `|I|`-vs-`|Q|` test's `K1 = 0.0247` low-pass
  is specified for 20 ms epochs and gives a 40-epoch time constant, but it was reset every 80 ms
  block, so the value actually tested had reached only ~39 % of its asymptote. It is replaced by
  the narrowband difference/power phase-lock indicator `Σ(I²−Q²)/Σ(I²+Q²)`, expectation
  `cos(2φ)·ρ/(ρ+1)`, as two exponential moving averages sharing one gain and never reset. Its
  expectation is closed-form, so the threshold maps to an explicit phase error: the default
  `0.25` (PocketSDR's `THRES_PLI`) demands `|φ| ≤ 30°` at the 30 dBHz the code detector accepts
  over a 1 ms record, and read as a pure sensitivity floor it is 25.2 dBHz — so the code detector
  stays the binding limit rather than competing.

Two fail-closed guards, both real bugs: a non-finite prompt poisoned both averages into a state
that read as "nothing measured yet" forever and held a dead channel in lock, and an empty prompt
sequence now advances the timers without inventing evidence.

The window is named `smoothing_records`, not code periods: its gain is applied once per prompt,
and a prompt spans `get_last_fully_integrated_num_code_blocks` code blocks, so a code-period name
would promise an invariance that only holds while `preferred_num_code_blocks_to_integrate` is 1.

**3. `feat: stage the lock detectors through the acquisition handover.`** Both detectors' dwell
moves into a shared `LockDwell` with two stages: a **pull-in** stage with a 600-code-period
allowance, latching permanently into a tighter 200-period **steady state** on either sustained
good evidence or expiry of an 800-period window. Ranging is gated separately and *later*, by
`is_ranging_ready` (600 periods of clean evidence, backstopped by a 2000-period timer), which
`collect_pvt_sat_states!` now requires.

Two stages rather than one long dwell because they answer different questions: the dwell wants to
tighten early so a post-handover fade is caught fast, while admission to ranging wants to be late
because C/N0 recovers long before the code loop does. Both latch conditions are needed too —
without the evidence one, a satellite that converges quickly stays nominally in pull-in and
notices a later fade far too slowly; without the timer, one that never settles never leaves.

**4. `feat(gui): draw still-settling satellites yellow in the CN0 panel.`**
`SatelliteDataOfInterest` carries `is_ranging_ready`, and the CN0 panel draws a still-settling
satellite yellow rather than green (red stays "the satellite declares itself unhealthy", which is
not something better tracking can fix). Without it, a satellite deliberately kept through the
handover is indistinguishable on screen from one the PVT solve is ignoring for no reason.

## Where the constants come from

**Every number was re-derived from scratch under Tracking's default `NoiseRefCN0Estimator`.** The
earlier version of this PR measured through `MomentsCN0Estimator`, which reads ~2.9 dB high at
25 dBHz and reports a median 27.6 dBHz on pure noise, so none of its figures could be carried
over.

The measurement generates a synthetic signal per system, hands it to `track!` with the initial
code phase and Doppler offset by this receiver's own worst-case acquisition residual, and drives
the detectors chunk by chunk exactly as `update_all_receiver_sat_states` does. Parameters are
recorded in commit 3's message; the two that matter most:

- **the sampling rate is per signal**, the lowest standard rate that can carry the modulation:
  2.048 MHz for GPS L1 C/A (the ION reference recording's own), 8.192 MHz for GPS L1C-D,
  12.288 MHz for Galileo E1B (its CBOC needs 12× the code rate). Sampling a BOC signal at the
  bare 2× code rate leaves one sample per BOC half-chip, at which the `VeryEarlyPromptLate`
  correlator's taps collapse onto the prompt and the DLL cannot track at all;
- **the residual follows from that rate**: half an acquisition bin of Doppler (125 / 31.2 /
  12.5 Hz) and half a sample of code phase (0.250 / 0.042 / 0.062 chip).

Calibration: with no handover error the reported C/N0 lands within 0.7 dB of truth on all three
signals and the DLL converges to milli-chip residuals.

### Peak accumulated out-of-lock time through the handover

This is the quantity `pull_in_out_of_lock_code_periods` has to cover: how much out-of-lock time a
satellite banks while its loops pull the coarse acquisition estimate in. Each cell is **the worst
of three noise seeds, in code periods** — a sizing number wants the worst case, not an average.
For reference, the steady-state dwell tolerates **200** and the new pull-in stage **600**.

**Code detector:**

| Signal | 31 dBHz | 32 dBHz | 34 dBHz |
|---|---|---|---|
| GPS L1 C/A | 4536 | **292** | 0 |
| Galileo E1B | 182 | 6 | 0 |
| GPS L1C-D | 0 | 0 | 0 |

So the worst demand from a satellite the receiver should keep is **292 code periods** — more than
the 200-period steady-state dwell tolerates, so a single un-staged dwell drops it, and 600 keeps
roughly a 2× margin. The spread across seeds is wide near threshold (that 292 cell ran 44 / 292 /
192; the 4536 cell ran 808 / 4320 / 4536), which is itself the point: at 31 dBHz the demand is
unbounded in practice, and those satellites are correctly dropped rather than held. By 34 dBHz
nothing accumulates at all on any signal.

**Carrier detector**, same runs — larger, because the FLL has to pull in the residual Doppler
before `cos(2φ)` stops averaging to zero:

| Signal | 31 dBHz | 32 dBHz | 34 dBHz |
|---|---|---|---|
| GPS L1 C/A | 4720 | 3108 | 588 |
| Galileo E1B | 208 | 159 | 115 |
| GPS L1C-D | 111 | 104 | 98 |

Its own dwell is 4000 code periods and clears outright on any favourable chunk, so it never loses
lock over this. But it does keep resetting `settled_time` — 588 code periods of it at a perfectly
healthy 34 dBHz on GPS L1 C/A, long after the code detector is content — and that is what makes
the ranging backstop necessary.

### Residual code phase against settled time (0.25-chip handover, GPS L1 C/A)

| latch at | residual Δτ | pseudorange error |
|---|---|---|
| 200 code periods | 0.15–0.22 chip | **44–64 m** |
| 600 code periods | 0.018–0.15 chip | **5–44 m** |

This is why ranging needs its own, later latch, and it independently reproduces the earlier
version's 26–54 m / 2–27 m.

### Steady-state per-chunk out-of-lock rate, no handover error

| Signal | 30 dBHz | 31 dBHz | ≥ 32 dBHz |
|---|---|---|---|
| GPS L1 C/A | 0.584 | 0.101 | 0.000 |
| Galileo E1B | 0.689 | 0.000 | 0.000 |
| GPS L1C-D | 0.725 | 0.000 | 0.000 |

Much sharper than the moment ratio's 0.42 / 0.23 / 0.095, so the **stochastic** half of the
ranging backstop's justification is weaker than the earlier version claimed. The **deterministic**
half is untouched and is the real argument: `settled_time` is reset by any out-of-lock verdict, so
against a disturbance recurring on any period shorter than the run the evidence path never fires
at all, at any C/N0 — and the carrier detector's own pull-in transient puts a satellite in exactly
that regime after every handover. The backstop stays.

## What the staging buys, end to end

Production detectors versus the old absolute 80 ms / 200 ms configuration, same handover,
percentage of chunks reported out of lock over 1000 chunks (three seeds):

Cells are the **range over three noise seeds** (a single value means all three agreed):

| Signal | CN0 | OLD % unlocked | NEW % unlocked | OLD first loss |
|---|---|---|---|---|
| GPS L1 C/A | 30 dBHz | 91.4–93.1 % | 83.1 % | 280 `T` |
| GPS L1 C/A | 31 dBHz | 20.2–93.1 % | 10.5–80.8 % | 280–328 `T` |
| GPS L1 C/A | 32 dBHz | 0–8.5 % | **0 %** | 312 `T` (1 of 3 seeds) |
| Galileo E1B | 30 dBHz | 84.4–93.1 % | **12.3–32.1 %** | 70 `T` |
| Galileo E1B | 31 dBHz | 15.1–34.7 % | **0 %** | 70 `T` |
| Galileo E1B | 32 dBHz | 0–2.7 % | **0 %** | 75 `T` (1 of 3 seeds) |
| GPS L1C-D | 30 dBHz | 53.3–93.1 % | **0 %** | 28 `T` |
| GPS L1C-D | 31 dBHz | 11.2–17.7 % | **0 %** | 28 `T` |
| GPS L1C-D | 32 dBHz | 0 % | 0 % | never |

"OLD first loss" is the elapsed signal time, in code periods, at which the old configuration first
declared the satellite lost.

Two things worth stating plainly, because they correct the earlier version of this PR:

- **above threshold + 2 dB neither configuration loses lock** at these sampling rates. The staging
  earns its keep in the 1–2 dB above threshold where a real marginal satellite lives, not at
  healthy C/N0.
- **the "~12 dB deficit for BOC(1,1)" claim is retracted.** It assumed a 0.25-chip residual, which
  needs a ~2 MHz sampling rate — and at that rate the BOC correlator's taps collapse and the DLL
  cannot track at all. At a rate that *can* track BOC the half-sample residual is 0.04–0.06 chip
  and the deficit is around a dB. The bug is real and reproduces; its mechanism on the BOC signals
  is the *absolute* 280 ms grace being only 28–70 code periods, not a large C/N0 deficit.

`is_ranging_ready` on a real handover fires at **764–1512 code periods** on GPS L1 C/A (766–918 on
E1B, 877 on L1C-D) against an **680-period floor**: the carrier loop's own Doppler pull-in keeps
resetting the evidence run. The docs and docstrings quote the floor as a floor with the measurement
alongside it — the earlier version quoted 680 as if it were typical.

## Folded in from `main`, absent from the earlier version

This PR is now based on `main` at v4.2.0 (vector tracking, Tracking 8), so three things had to be
reconciled rather than ported:

- **`OUT_OF_LOCK_TIME_CAP_FACTOR`'s capped payback is now stage-aware.** Capping at twice the
  fixed steady-state threshold would silently truncate the 600-period pull-in allowance to 400 —
  the headline feature two-thirds implemented, with no test failing.
- **`set_out_of_lock` raises the clock to the current stage's threshold.** `force_out_of_lock` in
  `vector_tracking.jl` calls it (and without it `main` does not compile); a release that does not
  flip the lock verdict on the spot silently no-ops, and the fixed steady-state value would leave
  a satellite still in pull-in in lock.
- **`is_ranging_ready(::ReceiverSatState)` mirrors `is_in_lock`'s `in_vt_loop` branch** — code
  detector only for a vector-loop member. An unconditional AND would permanently exclude a member
  that joined the loop before its carrier latch fired, since a coasted member's carrier EMA is
  starved through the outage. The latch is sticky for the same reason: the filter steers both NCOs
  through an outage, so a returning member is immediately rangeable.

The `!!! note "The threshold cannot usefully be lowered"` admonition is dropped rather than merged:
it rests on `MomentsCN0Estimator`'s 27.6 dBHz noise floor, which `main`'s own docstring already
contradicts for the noise reference. Under the noise reference the threshold *could* be lowered —
that is a separate question and not attempted here.

## Test coverage

`LockDwell` gets its own testsets for the two stages, both latches, the stage transition (a dwell
whose clock is over the steady threshold when the pull-in window expires must not be declared lost),
the ranging backstop (including a disturbance-period sweep and the structural guarantee that
`is_ranging_ready ⟹ has_pulled_in`), and constructor validation. The carrier indicator's
expectation is checked against `cos(2φ)·ρ/(ρ+1)` over an SNR × phase grid, its noise-only
percentiles are measured rather than asserted, and batched-versus-scalar `update` equivalence plus
a subsampling-spread comparison pin the "every prompt" fix. The PVT gate is tested where it lives:
`is_ranging_ready` on a `ReceiverSatState` is an AND over both detectors (all four combinations,
plus the vector-loop branch), and `collect_pvt_sat_states!` excludes an in-lock, past-the-time-gate
satellite that is not ranging-ready while admitting an otherwise identical one that is — plus a
ranging-ready satellite still held out by `time_in_lock_before_calculating_pvt`, so the new gate is
not the old one in disguise. Every fixture is built by driving `update`, never by writing struct
fields, so they survive a retuning of the thresholds.

Three existing assertions move, all predicted by the staging itself: the cap test saturates at
`2 × 600 ms` and needs 151 updates of payback rather than 51; noise-only loss moves from 70 updates
to 170 (20 warm-up + 150 dwell at 4 ms); and the moments-driven drives lengthen from 200 to 500
updates.

## Regression

Full suite passes at each of the four commits, including both ION RTL-SDR integration runs
(`ComplexF32` and `Complex{Int16}`) and the vector-tracking run: the same 11 healthy PRNs, the same
position, velocity, epoch, clock bias, DOPs and per-satellite CN0 baselines, and the
reacquisition-after-slip test with identical figures (11 locked before the slip, 0 at the minimum
after it, 11 at the end). On real GPS L1 C/A the timing change is behaviour-neutral by
construction, since 200 code periods is 200 ms there.

Worth recording: **the ION recording cannot reproduce this bug.** It is GPS L1 C/A only, where the
old timings were correct. Reproducing the failure needs a longer code period or a synthetic
handover.

Expect a small, real benchmark regression on the tracking stages: four times the carrier-detector
arithmetic per chunk at the default cadence. Note also that `benchmark/benchmarks.jl` picks its
timed windows with `num_in_lock(rs) >= 4 && !has_fix(rs)`, so an earlier pull-in latch can shift
the window to a different second of the recording — check the stage boundaries before reading a
delta as slower code.

## Follow-ups, deliberately not in this PR

- **Driving the detectors per record.** They run at the chunk cadence while their statistics live
  at the record cadence.
- **Gating vector-loop admission on `is_ranging_ready`.** `prns_in_lock` serves both the
  `enable_vt!` list and the measurement-eligibility list handed to `collect_vt_members!`, so
  gating it would also withhold discriminators from existing members. The two uses need separating
  first.
- **Weighting marginal satellites in the PVT solve.** Measurement variance should follow C/N0, but
  `PositionVelocityTime` currently solves plain OLS (JuliaGNSS/PositionVelocityTime.jl#65).
- **`ConventionalAssistedPLLAndDLL`'s stable false lock at `Δf = 1/(2T)`.** Out of reach of this
  receiver's own ±125 Hz acquisition bin sizing; catching it would need a code-carrier divergence
  or dot/cross alias check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
